### PR TITLE
feat: [TIKI-18] make config more similar to RBAC PolicyRules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,10 +26,24 @@ type Config struct {
 }
 
 type ScanType struct {
-	schema.GroupVersionKind `json:",inline"`
-	// Namespaces allows to restrict scrapes to specific namespaces. An empty list means all
+	// TODO: because this isn't RBAC, the "multiple groups, multiple resources" idea is a bit
+	// tricky. In RBAC, if you have n apiGroups and m resources, not all of these combinations need
+	// to exist (e.g. n[1] x m[1] may not necessarily be an existing resource type). The config
+	// validation currently fails on such combinations, because we couldn't scan it. We might want
+	// to just log that out instead.
+	// TODO: The "*" group / resource specifier isn't implemented yet.
+	APIGroups []string `json:"apiGroups"`
+	Resources []string `json:"resources"`
+	// Versions is an optional field to specify which exact versions should be scanned. If unset,
+	// the scanner will use the API Server's preferred version.
+	// TODO: "*" wildcard is not supported yet.
+	Versions []string `json:"versions"`
+	// Namespaces allows to restrict scanning to specific namespaces. An empty list means all
 	// namespaces.
 	Namespaces []string `json:"namespaces"`
+	// GKVs contains the parsed groupVersionKinds that have been extracted from the APIGroups /
+	// Resources / Version.
+	GVKs []schema.GroupVersionKind `json:"-"`
 }
 
 type Scan struct {
@@ -80,34 +94,112 @@ func (c *Config) Validate() error {
 	return c.validate(cs.Discovery())
 }
 
-func (c *Config) validate(discoveryClient discovery.DiscoveryInterface) error {
-	cache := make(map[string]*metav1.APIResourceList)
+type discoveryHelper struct {
+	discovery.DiscoveryInterface
+	// to cache all group versions that we retrieve.
+	resourcesForGroupVersion map[schema.GroupVersion][]metav1.APIResource
+	groups                   []metav1.APIGroup
+}
 
-nextType:
-	for _, gvk := range c.Scanning.Types {
-		gv := gvk.GroupVersion().String()
-		list, ok := cache[gv]
-		if !ok {
-			var err error
-			list, err = discoveryClient.ServerResourcesForGroupVersion(gv)
-			if err != nil {
-				var statusErr *k8serrors.StatusError
-				if errors.As(err, &statusErr) && statusErr.Status().Code == http.StatusNotFound {
-					return fmt.Errorf("GroupVersion %v does not seem to be supported by the server",
-						gvk.String())
-				}
-				return fmt.Errorf("could not get server resources for groupversion %v: %w", gv, err)
-			}
-			cache[gv] = list
-		}
-
-		for _, res := range list.APIResources {
-			if res.Kind == gvk.Kind {
-				continue nextType
-			}
-		}
-
-		return fmt.Errorf("Kind %v does not seem to be supported by the server", gvk.String())
+func newDiscoveryHelper(discoveryClient discovery.DiscoveryInterface) (*discoveryHelper, error) {
+	groups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return nil, err
 	}
+
+	return &discoveryHelper{
+		DiscoveryInterface:       discoveryClient,
+		resourcesForGroupVersion: make(map[schema.GroupVersion][]metav1.APIResource),
+		groups:                   groups.Groups,
+	}, nil
+}
+
+func (d *discoveryHelper) preferredVersionForGroup(apiGroup string) (string, error) {
+	for _, group := range d.groups {
+		if group.Name == apiGroup {
+			return group.PreferredVersion.Version, nil
+		}
+	}
+	return "", fmt.Errorf("group %v does not exist", apiGroup)
+}
+
+// findGVK returns the GroupVersionKind for the given group, resource and version. Version is
+// optional, and if empty, the preferred version of the API Server will be used.
+func (d *discoveryHelper) findGVK(apiGroup, resource, version string) (schema.GroupVersionKind, error) {
+	gv := schema.GroupVersion{Group: apiGroup, Version: version}
+	if gv.Version == "" {
+		var err error
+		gv.Version, err = d.preferredVersionForGroup(apiGroup)
+		if err != nil {
+			return schema.GroupVersionKind{}, err
+		}
+	}
+
+	resources, ok := d.resourcesForGroupVersion[gv]
+	if !ok {
+		list, err := d.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			var statusErr *k8serrors.StatusError
+			if errors.As(err, &statusErr) && statusErr.Status().Code == http.StatusNotFound {
+				return schema.GroupVersionKind{}, fmt.Errorf(
+					"GroupVersion %v does not seem to be supported by the server", gv,
+				)
+			}
+			return schema.GroupVersionKind{}, fmt.Errorf(
+				"could not get server resources for groupversion %v: %w", gv, err,
+			)
+		}
+
+		d.resourcesForGroupVersion[gv] = list.APIResources
+		resources = list.APIResources
+	}
+
+	for _, res := range resources {
+		if res.Name == resource {
+			return schema.GroupVersionKind{
+				Group:   gv.Group,
+				Version: gv.Version,
+				Kind:    res.Kind,
+			}, nil
+		}
+	}
+
+	return schema.GroupVersionKind{}, fmt.Errorf("group version %v does not have resource %v",
+		gv, resource)
+}
+
+// validate the configuration, and add all computed fields to the config. Returns an error if the
+// config should be invalid or the validity of the config couldn't be determined.
+func (c *Config) validate(discoveryClient discovery.DiscoveryInterface) error {
+	dh, err := newDiscoveryHelper(discoveryClient)
+	if err != nil {
+		return err
+	}
+
+	for i, st := range c.Scanning.Types {
+		var gvks []schema.GroupVersionKind
+		// create a n x m "matrix" of all apiGroups & resource combination.
+		for _, stAPIGroup := range st.APIGroups {
+			for _, stResource := range st.Resources {
+				versions := st.Versions
+				// TODO: improve this with https://snyksec.atlassian.net/browse/TIKI-20
+				if len(versions) == 0 {
+					versions = append(versions, "")
+				}
+				for _, stVersion := range versions {
+					gvk, err := dh.findGVK(stAPIGroup, stResource, stVersion)
+					if err != nil {
+						// TODO: we should probably log errors And continue anyway, so that not all
+						// combinations of the n x m matrix need to exist.
+						return fmt.Errorf("could not find GVK for group %v, resource %v, version %v: %w",
+							stAPIGroup, stResource, st.Versions, err)
+					}
+					gvks = append(gvks, gvk)
+				}
+			}
+		}
+		c.Scanning.Types[i].GVKs = gvks
+	}
+
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -191,22 +191,14 @@ func newTest(t *testing.T) test {
 			},
 		},
 		types: []config.ScanType{{
-			GroupVersionKind: schema.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-			}}, {
-			GroupVersionKind: schema.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "ConfigMap",
-			}, Namespaces: []string{"foo"}}, {
-			GroupVersionKind: schema.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Pod",
-			}},
-		},
+			APIGroups: []string{""},
+			Resources: []string{"secrets", "pods"},
+			Versions:  []string{"v1"},
+		}, {
+			APIGroups:  []string{""},
+			Resources:  []string{"configmaps"},
+			Namespaces: []string{"foo"},
+		}},
 	}
 }
 


### PR DESCRIPTION
This commit makes the scanner's configuration adhere to the RBAC's "PolicyRule" type which is used within (Cluster)Roles. Without this, the user would have needed to specify different information for the scanner's config and the RBAC config, resulting in duplication. Instead, the user can now simply write a slightly enhanced RBAC-style config (having an additional "Namespaces" and "Version" field), which is then easily translated to the ClusterRole and scanner config.