### PR TITLE
[TIKI-3] feat: implement store backend to send data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,10 @@ jobs:
       - go/mod-download
       - run:
           command: |
+            go mod tidy
+            git diff --quiet HEAD
+      - run:
+          command: |
             golangci-lint run -v --timeout=2m ./...
           environment:
             # we re-use the Go build cache as our lint-cache too.

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,209 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var timeNow time.Time
+
+func init() {
+	var err error
+	timeNow, err = time.Parse(time.RFC3339, "2023-02-20T16:41:17Z")
+	if err != nil {
+		panic("could not parse time!")
+	}
+
+	now = func() time.Time {
+		return timeNow
+	}
+}
+
+func TestBackend(t *testing.T) {
+	const orgID = "org-123"
+	ctx := context.Background()
+	tu := testUpstream{orgID: orgID}
+	ts := httptest.NewServer(http.HandlerFunc(tu.Handle))
+	defer ts.Close()
+
+	b := New(ts.URL, "my-pet-cluster")
+	err := b.Upsert(ctx, pod, orgID, nil)
+	require.NoError(t, err)
+
+	tu.deletion = true
+	err = b.Upsert(ctx, pod, orgID, &metav1.Time{Time: now().Local()})
+	require.NoError(t, err)
+
+	// make sure that our error handling also works; our upstream currently expects a
+	// delete-request, but we're sending a zero-time, so it will return an error. That error should
+	// be passed through to the caller of Upsert.
+	err = b.Upsert(ctx, pod, orgID, nil)
+	require.Error(t, err)
+}
+
+type testUpstream struct {
+	orgID    string
+	deletion bool
+}
+
+func (tu *testUpstream) Handle(w http.ResponseWriter, r *http.Request) {
+	matches, err := path.Match(fmt.Sprintf("*/rest/orgs/%s/kubernetesresources", tu.orgID), r.URL.Path)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid path, could not match: %v", err), 400)
+		return
+	}
+	if !matches {
+		http.Error(w, fmt.Sprintf("path does not match expectations: %v", r.URL.Path), 400)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("could not read body: %v", err), 400)
+		return
+	}
+
+	req := request{}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf("could not unmarshal body to JSON: %v", err), 400)
+		return
+	}
+
+	expected := []resource{{
+		ManifestBlob: pod,
+		// when unmarshaling from JSON, metav1.Time also calls Local(), so we need to do too.
+		ScannedAt: metav1.Time{Time: now().Local()},
+	}}
+
+	if tu.deletion {
+		expected[0].DeletedAt = &metav1.Time{Time: now().Local()}
+	}
+
+	if !assert.ObjectsAreEqual(expected, req.Data.Attributes.Resources) {
+		http.Error(w,
+			fmt.Sprintf("objects are not equal. expected=%+v, got=%+v", expected, req.Data.Attributes.Resources),
+			400)
+		return
+	}
+}
+
+var pod = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "normal-pod",
+		Namespace: "default",
+	},
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Pod",
+		APIVersion: "v1",
+	},
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "bla",
+			Image: "bla:latest",
+		}},
+	},
+}
+
+// UnmarshalJSON unmarshals the resource type. This needs a custom unmarshal function because the
+// resource type contains a `client.Object` interface, which cannot be unmarshalled automatically.
+func (r *resource) UnmarshalJSON(data []byte) error {
+	// create a temporary type to avoid recursive calls to this method.
+	type s resource
+	tmp := s{
+		// we simply set the manifestBlob to an unstructured object, which satisfies the
+		// `client.Object` interface and allows us to extract the apiVersion & kind from it.
+		ManifestBlob: &unstructured.Unstructured{},
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	// figure out the actual type of the manifestBlob and add it to tmp so that we can do another
+	// round of json unmarshaling.
+	apiVersion, kind := tmp.ManifestBlob.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	switch {
+	case kind == "Pod" && apiVersion == "v1":
+		tmp.ManifestBlob = &corev1.Pod{}
+	default:
+		return fmt.Errorf("unknown APIVersion / Kind %v in %s", tmp, data)
+	}
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	// the GVK is lost when unmarshalling / decoding objects, so we need to add it back.
+	// https://github.com/kubernetes/client-go/issues/541#issuecomment-452312901
+	tmp.ManifestBlob.GetObjectKind().SetGroupVersionKind(tmp.ManifestBlob.GetObjectKind().GroupVersionKind())
+	*r = resource(tmp)
+	return nil
+}
+
+func TestJSONMatches(t *testing.T) {
+	b := New("", "my pet cluster")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "a-pod",
+			Namespace: "default",
+			UID:       types.UID("ADD9E4F4-5154-4261-81FD-F14A4358F772"),
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+	}
+	r, err := b.newPostBody(pod, nil)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, body, "", "\t")
+	require.NoError(t, err)
+
+	const expectedJSON = `{
+	"data": {
+		"type": "kubernetesresource",
+		"attributes": {
+			"cluster_name": "my pet cluster",
+			"resources": [
+				{
+					"manifest_blob": {
+						"kind": "Pod",
+						"apiVersion": "v1",
+						"metadata": {
+							"name": "a-pod",
+							"namespace": "default",
+							"uid": "ADD9E4F4-5154-4261-81FD-F14A4358F772",
+							"creationTimestamp": null
+						},
+						"spec": {
+							"containers": null
+						},
+						"status": {}
+					},
+					"scanned_at": "2023-02-20T16:41:17Z"
+				}
+			]
+		}
+	}
+}`
+	require.Equal(t, expectedJSON, prettyJSON.String())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	Scanning       Scan   `json:"scanning"`
 	MetricsAddress string `json:"metricsAddress"`
 	ProbeAddress   string `json:"probeAddress"`
+	// OrganizationID is the snyk organization ID where data should be routed to.
+	OrganizationID string `json:"organizationID"`
 
 	Scheme     *runtime.Scheme `json:"-"`
 	RestConfig *rest.Config    `json:"-"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,7 @@ type Scan struct {
 }
 
 // Read reads the config file from the specificied flag "-config" and returns a
-// struct that contains all options, including other flags. It is ensured that
-// the config is valid, see the Validate method for details.
+// struct that contains all options, including other flags.
 func Read(configFile string) (*Config, error) {
 	if configFile == "" {
 		return nil, fmt.Errorf("no config file set!")
@@ -60,6 +59,10 @@ func Read(configFile string) (*Config, error) {
 	}
 	if err := yaml.Unmarshal(b, c); err != nil {
 		return nil, fmt.Errorf("could not unmarshal config file: %w", err)
+	}
+
+	if c.OrganizationID == "" {
+		return nil, fmt.Errorf("organization ID is missing in config file")
 	}
 
 	return c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,7 @@ func TestConfigRealAPIServer(t *testing.T) {
 
 	const actualConfig = `
 metricsAddress: ":8080"
+organizationID: "some-id"
 scanning:
   requeueAfter: 1m
   types:
@@ -42,6 +43,7 @@ scanning:
 
 	expected := &Config{
 		MetricsAddress: ":8080",
+		OrganizationID: "some-id",
 		Scanning: Scan{
 			RequeueAfter: metav1.Duration{Duration: time.Minute},
 			Types: []ScanType{{


### PR DESCRIPTION
This commit adds the "backend" within the scanner (renamed to `store`) that is able to send data to our kubernetes-resource-store.

There's currently a hardcoded URL in `main.go`, we'll likely need to adjust that and probably make it configurable _somehow_ (I don't think we'll want to have that in the config file though...)