### PR TITLE
feat: improve config file & add more options

### DIFF
--- a/helm/kubernetes-scanner/templates/configmap.yaml
+++ b/helm/kubernetes-scanner/templates/configmap.yaml
@@ -11,7 +11,13 @@ metadata:
 data:
   "config.yaml": |
     metricsAddress: ":{{ .Values.metrics.port }}"
+    clusterName: "{{ .Values.config.clusterName }}"
+    organizationID: {{ required "An organizationID is required!" .Values.organizationID }}
     scanning:
-      requeueAfter: {{ .Values.requeueAfter }}
+      requeueAfter: {{ .Values.config.scanning.requeueAfter }}
       types:
-        {{- toYaml .Values.scanTypes | nindent 8 }}
+        {{- toYaml .Values.config.scanning.types | nindent 8 }}
+    egress:
+      httpClientTimeout: {{ .Values.config.egress.httpClientTimeout }}
+      snykAPIBaseURL: {{ .Values.config.egress.snykAPIBaseURL }}
+

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -2,11 +2,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-scanTypes:
-  - apiGroups: [""]
-    resources: ["pods"]
+# TODO: set cluster name & orgID
+#organizationID: "setme"
 
-requeueAfter: "6h"
+config:
+  clusterName: "default"
+  scanning:
+    types:
+      - apiGroups: [""]
+        resources: ["pods"]
+    requeueAfter: "6h"
+  egress:
+    httpClientTimeout: "5s"
+    snykAPIBaseURL: "https://app.dev.snyk.io"
 
 # secretName is the name of the secret containing auth credentials.
 # requires a key "snykServiceAccountToken"

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := setupController(cfg, backend.New(snykAPIEndpoint(), "my-cluster-name"))
+	mgr, err := setupController(cfg, backend.New(cfg.ClusterName, cfg.Egress))
 	if err != nil {
 		setupLog.Error(err, "unable to setup controller")
 		os.Exit(1)
@@ -63,16 +63,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func snykAPIEndpoint() string {
-	const defaultEndpoint = "https://kubernetes-store.snyk.io"
-
-	if api := os.Getenv("SNYK_API_ENDPOINT"); api != "" {
-		return api
-	}
-
-	return defaultEndpoint
 }
 
 func setupController(cfg *config.Config, s store) (manager.Manager, error) {


### PR DESCRIPTION
This commit extends the config file & handling to allow some further configuration of the deployed binary.
The following fields have been added:

- egress.httpClientTimeout
- egress.snykAPIBaseURL
- egress.snykServiceAccountToken (not read through config file, only through env variable)
- clusterName

Additionally, the baseURL setting has some validation to ensure that a scheme is always present.

This work is part of [TIKI-3](https://snyksec.atlassian.net/browse/TIKI-3)

[TIKI-3]: https://snyksec.atlassian.net/browse/TIKI-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ