### PR TITLE
fix: use correct URL for Helm chart

### DIFF
--- a/build/helmreleaser/github/github.go
+++ b/build/helmreleaser/github/github.go
@@ -65,5 +65,5 @@ func (rc *RepositoryClient) UploadToRelease(ctx context.Context, releaseTag stri
 		return "", fmt.Errorf("could not upload asset: %v", err)
 	}
 
-	return *asset.URL, nil
+	return *asset.BrowserDownloadURL, nil
 }


### PR DESCRIPTION
This commit fixes what I think would be a bug in the release-process of helm charts.
The current `index.yaml` for our Github Pages Helm Repository contains the following URL:
```yaml
    urls:
    - https://api.github.com/repos/snyk/kubernetes-scanner/releases/assets/99810634
```

However, this doesn't seem to be a "direct-download" style URL. Looking at the [Github docs](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset), the `BrowserDownloadURL` looks better :)