### PR TITLE
fix: include fileending in uploaded release asset

### DIFF
--- a/build/helmreleaser/github/github.go
+++ b/build/helmreleaser/github/github.go
@@ -42,7 +42,6 @@ func (rc *RepositoryClient) RepoURL() string {
 
 // An Artifact has a Name and is backed by a File.
 type Artifact interface {
-	Name() string
 	OpenFile() (*os.File, error)
 }
 
@@ -60,7 +59,7 @@ func (rc *RepositoryClient) UploadToRelease(ctx context.Context, releaseTag stri
 	}
 
 	asset, _, err := rc.client.UploadReleaseAsset(ctx, rc.repoOwner, rc.repoName, *release.ID,
-		&github.UploadOptions{Name: artifact.Name()}, af)
+		&github.UploadOptions{Name: path.Base(af.Name())}, af)
 	if err != nil {
 		return "", fmt.Errorf("could not upload asset: %v", err)
 	}

--- a/build/helmreleaser/helm/helm.go
+++ b/build/helmreleaser/helm/helm.go
@@ -15,8 +15,8 @@ import (
 )
 
 type PackagedChart struct {
-	name    string
-	version string
+	Name    string
+	Version string
 	File    string
 }
 
@@ -37,14 +37,12 @@ func PackageChart(name string, version string, path string) (*PackagedChart, err
 	}
 
 	return &PackagedChart{
-		name:    name,
-		version: version,
+		Name:    name,
+		Version: version,
 		File:    file,
 	}, nil
 }
 
-func (ch *PackagedChart) Name() string                { return ch.name }
-func (ch *PackagedChart) Version() string             { return ch.version }
 func (ch *PackagedChart) OpenFile() (*os.File, error) { return os.Open(ch.File) }
 
 func (ch *PackagedChart) UploadedTo(urls ...string) *UploadedChart {
@@ -61,9 +59,9 @@ type UploadedChart struct {
 
 func (ch *PackagedChart) Metadata() *helmchart.Metadata {
 	return &helmchart.Metadata{
-		Name:        ch.name,
-		Version:     ch.version,
-		Description: ch.name + " Chart",
+		Name:        ch.Name,
+		Version:     ch.Version,
+		Description: ch.Name + " Chart",
 		APIVersion:  chart.APIVersionV1,
 	}
 }
@@ -102,7 +100,7 @@ func UpdateIndexYAML(indexFile FileOverwriter, charts ...*UploadedChart) error {
 			return fmt.Errorf("error validating chart metadata: %w", err)
 		}
 
-		index.Entries[ch.name] = append(index.Entries[ch.name], &helmrepo.ChartVersion{
+		index.Entries[ch.Name] = append(index.Entries[ch.Name], &helmrepo.ChartVersion{
 			URLs:     ch.URLs,
 			Metadata: md,
 			Digest:   digest,

--- a/build/helmreleaser/main.go
+++ b/build/helmreleaser/main.go
@@ -63,7 +63,7 @@ func publish(chart *helm.PackagedChart, gitRepoUser, gitRepoName string) error {
 	}
 
 	gh := github.New(ctx, token, gitRepoUser, gitRepoName)
-	url, err := gh.UploadToRelease(ctx, chart.Version(), chart)
+	url, err := gh.UploadToRelease(ctx, chart.Version, chart)
 	if err != nil {
 		return fmt.Errorf("could not upload chart to Github: %w", err)
 	}


### PR DESCRIPTION
I'm not 100% sure if it's required, but it won't hurt. Looking at other `index.yaml`, they're adding it as well.