### PR TITLE
sensible default types

### DIFF
--- a/helm/kubernetes-scanner/templates/rbac.yaml
+++ b/helm/kubernetes-scanner/templates/rbac.yaml
@@ -18,12 +18,12 @@ kind: ClusterRole
 metadata:
   name: {{ include "kubernetes-scanner.fullname" . }}
 rules:
-  {{- range .Values.scanTypes }}
+  {{- range .Values.config.scanning.types }}
   - verbs: ["watch", "list", "get"]
     apiGroups: 
-      {{ toYaml .apiGroups }}
+      {{- toYaml .apiGroups | nindent 6}}
     resources: 
-      {{ toYaml .resources }}
+      {{- toYaml .resources | nindent 6}}
   {{- end }}
 
 ---

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -26,7 +26,95 @@ config:
   scanning:
     types:
       - apiGroups: [""]
-        resources: ["pods"]
+        resources:
+          - pods
+          - services
+          - namespaces
+          - replicationcontrollers
+          - nodes
+          - configmaps
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        resources:
+          - clusterroles
+          - roles
+          - clusterrolebindings
+          - rolebindings
+      - apiGroups: ["batch"]
+        resources:
+          - cronjobs
+          - jobs
+      - apiGroups: ["apps"]
+        resources:
+          - replicasets
+          - daemonsets
+          - deployments
+          - statefulsets
+      - apiGroups: ["networking.k8s.io"]
+        resources:
+          - ingresses
+      - apiGroups: ["apps.openshift.io"]
+        resources:
+          - deploymentconfigs
+      - apiGroups: ["argoproj.io"]
+        resources:
+          - rollouts
+      - apiGroups: ["gateway.solo.io"]
+        resources:
+          - gateways
+          - httpgateways
+          - routeoptions
+          - routetables
+          - virtualhostoptions
+          - virtualservices
+      - apiGroups: ["getambassador.io"]
+        resources:
+          - consulresolvers
+          - devportals
+          - hosts
+          - kubernetesendpointresolvers
+          - kubernetesserviceresolvers
+          - listeners
+          - logservices
+          - mappings
+          - modules
+          - ratelimitservices
+          - tcpmappings
+          - tracingservices
+      - apiGroups: ["gloo.solo.io"]
+        resources:
+          - proxies
+          - upstreamgroups
+          - upstreams
+      - apiGroups: ["graphql.gloo.solo.io"]
+        resources:
+          - graphqlschemas
+      - apiGroups: ["install.istio.io"]
+        resources:
+          - istiooperators
+      - apiGroups: ["networking.gke.io"]
+        resources:
+          - managedcertificates
+          - serviceattachments
+          - frontendconfigs
+          - servicenetworkendpointgroups
+      - apiGroups: ["networking.istio.io"]
+        resources:
+          - destinationrules
+          - envoyfilters
+          - gateways
+          - serviceentries
+          - sidecars
+          - virtualservices
+          - workloadentries
+          - workloadgroups
+      - apiGroups: ["ratelimit.solo.io"]
+        resources:
+          - ratelimitconfigs
+      - apiGroups: ["security.istio.io"]
+        resources:
+          - authorizationpolicies
+          - peerauthentications
+          - requestauthentications
     requeueAfter: "6h"
   egress:
     httpClientTimeout: "5s"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,7 +204,7 @@ func (st ScanType) getVersions(group string, d Discovery) ([]string, error) {
 	case len(st.Versions) == 0:
 		version, err := d.preferredVersionForGroup(group)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not get preferred version for group %v: %w", group, err)
 		}
 		return []string{version}, nil
 
@@ -257,7 +257,7 @@ func (d *discoveryHelper) preferredVersionForGroup(apiGroup string) (string, err
 			return group.PreferredVersion.Version, nil
 		}
 	}
-	return "", fmt.Errorf("group %v does not exist", apiGroup)
+	return "", newNotFoundError(schema.GroupVersionResource{Group: apiGroup})
 }
 func (d *discoveryHelper) versionsForGroup(apiGroup string) ([]string, error) {
 	for _, group := range d.groups {


### PR DESCRIPTION
**fix: reference to scan config**

This commit fixes the Helm chart's rendering of our scan types in the
ClusterRole.



**feat: improve default types**

This commit updates / adjusts the default types that are being scanned.
This list has been built based on the kubernetes-monitor RBAC list (see
[TIKI-39](https://snyksec.atlassian.net/browse/TIKI-39) for a link).


[TIKI-39]: https://snyksec.atlassian.net/browse/TIKI-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ