### PR TITLE
fix: image push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,12 +183,18 @@ workflows:
           context:
             - snyk-docker-build
             - snyk-apps
-            # This context contains a Personal Access Token from the snyk-deployer account.
-            # It's used to push commits & the Helm chart to the Github release. It is named
-            # "kubernetes-scanner Helm release CI" and will expire on Jan 06, 2024.
-            # To regenerate a token, login with the snyk-deployer account, create a token
-            # and add it / update the context.
-            - kubernetes-scanner-helm-release
+            # There's two types of tokens in this, the Docker credentials
+            # (username & password) and a Github PAT. Both are stored in
+            # 1Password ("DockerHub TIKI kubernetes-scanner" and "Github TIKI
+            # kubernetes-scanner"). The Github PAT will expire on March 27, 2024
+            # and will need to be rotated by logging in with the "snyk-deployer"
+            # account in Github. Do not forget to "Authorize SSO" on the new
+            # token. The same goes for the docker credentials, where you'll
+            # need to login with "snykdocker"
+            #
+            # The Github Token is used to push commits & the Helm chart to the
+            # Github release. The Docker token to publish the Docker image.
+            - tiki-kubernetes-scanner-release
           filters:
             branches:
               ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ image:
 		--build-arg GIT_TAG="${CIRCLE_TAG}" \
 		.
 image-push:
-	$(DOCKER) push -a snyk/kubernetes-scanner:$(TAG)
+	$(DOCKER) push --all-tags snyk/kubernetes-scanner
 
 chart:
 	$(GOCMD) run ./build/helmreleaser -version=$(TAG) -publish=false


### PR DESCRIPTION
This commit fixes an issue with pushing the images.

```
docker push -a snyk/kubernetes-scanner:v0.5.0
tag can't be used with --all-tags/-a
```