### PR TITLE
[TIKI-32] feat: send preferred version

### DIFF
--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -48,37 +48,44 @@ config:
         # a list of API versions that should be scanned. If unset, the
         # APIServer's "preferredVersion" will be used. Can also specify
         # multiple to scan for multiple versions at once.
-        versions: ["v1"]
+        versions: ["*"]
         # an empty list (or not defining this key at all) does not limit
         # scanning to any namespace. E.g. "namespaces: ["default"]" would limit
         # the scanner to only scan for pods in the default namespace.
         namespaces: []
       - apiGroups: ["rbac.authorization.k8s.io"]
+        versions: ["*"]
         resources:
           - clusterroles
           - roles
           - clusterrolebindings
           - rolebindings
       - apiGroups: ["batch"]
+        versions: ["*"]
         resources:
           - cronjobs
           - jobs
       - apiGroups: ["apps"]
+        versions: ["*"]
         resources:
           - replicasets
           - daemonsets
           - deployments
           - statefulsets
       - apiGroups: ["networking.k8s.io"]
+        versions: ["*"]
         resources:
           - ingresses
       - apiGroups: ["apps.openshift.io"]
+        versions: ["*"]
         resources:
           - deploymentconfigs
       - apiGroups: ["argoproj.io"]
+        versions: ["*"]
         resources:
           - rollouts
       - apiGroups: ["gateway.solo.io"]
+        versions: ["*"]
         resources:
           - gateways
           - httpgateways
@@ -87,6 +94,7 @@ config:
           - virtualhostoptions
           - virtualservices
       - apiGroups: ["getambassador.io"]
+        versions: ["*"]
         resources:
           - consulresolvers
           - devportals
@@ -101,23 +109,28 @@ config:
           - tcpmappings
           - tracingservices
       - apiGroups: ["gloo.solo.io"]
+        versions: ["*"]
         resources:
           - proxies
           - upstreamgroups
           - upstreams
       - apiGroups: ["graphql.gloo.solo.io"]
+        versions: ["*"]
         resources:
           - graphqlschemas
       - apiGroups: ["install.istio.io"]
+        versions: ["*"]
         resources:
           - istiooperators
       - apiGroups: ["networking.gke.io"]
+        versions: ["*"]
         resources:
           - managedcertificates
           - serviceattachments
           - frontendconfigs
           - servicenetworkendpointgroups
       - apiGroups: ["networking.istio.io"]
+        versions: ["*"]
         resources:
           - destinationrules
           - envoyfilters
@@ -128,9 +141,11 @@ config:
           - workloadentries
           - workloadgroups
       - apiGroups: ["ratelimit.solo.io"]
+        versions: ["*"]
         resources:
           - ratelimitconfigs
       - apiGroups: ["security.istio.io"]
+        versions: ["*"]
         resources:
           - authorizationpolicies
           - peerauthentications
@@ -138,7 +153,7 @@ config:
     requeueAfter: "6h"
   egress:
     httpClientTimeout: "5s"
-    snykAPIBaseURL: "https://app.dev.snyk.io"
+    snykAPIBaseURL: "https://api.snyk.io"
 
 # secretName is the name of the secret containing auth credentials.
 # requires a key "snykServiceAccountToken". You can find more information on

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,7 +26,7 @@ import (
 func TestGetGVKs(t *testing.T) {
 	testTypes := map[string]struct {
 		scanType     ScanType
-		expectedGVKs []schema.GroupVersionKind
+		expectedGVKs []GroupVersionKind
 	}{
 		"standard": {
 			scanType: ScanType{
@@ -34,14 +34,20 @@ func TestGetGVKs(t *testing.T) {
 				Versions:  []string{"v1"},
 				Resources: []string{"deployments", "pods"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
 			}, {
-				Group:   "",
-				Version: "v1",
-				Kind:    "Pod",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				},
 			}},
 		},
 		"inexistent-group-with-version-set": {
@@ -65,10 +71,13 @@ func TestGetGVKs(t *testing.T) {
 				Versions:  []string{"v1", "v1beta1"},
 				Resources: []string{"csidrivers"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "storage.k8s.io",
-				Version: "v1",
-				Kind:    "CSIDriver",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "storage.k8s.io",
+					Version: "v1",
+					Kind:    "CSIDriver",
+				},
 			}},
 		},
 		"multiple-versions-in-all-groups": {
@@ -77,22 +86,34 @@ func TestGetGVKs(t *testing.T) {
 				Versions:  []string{"v1", "v2"},
 				Resources: []string{"horizontalpodautoscalers", "scales"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "autoscaling",
-				Version: "v1",
-				Kind:    "HorizontalPodAutoscaler",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v1",
+					Kind:    "HorizontalPodAutoscaler",
+				},
 			}, {
-				Group:   "autoscaling",
-				Version: "v1",
-				Kind:    "Scale",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v1",
+					Kind:    "Scale",
+				},
 			}, {
-				Group:   "autoscaling",
-				Version: "v2",
-				Kind:    "HorizontalPodAutoscaler",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v2",
+					Kind:    "HorizontalPodAutoscaler",
+				},
 			}, {
-				Group:   "autoscaling",
-				Version: "v2",
-				Kind:    "Scale",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v2",
+					Kind:    "Scale",
+				},
 			}},
 		},
 		"preferred-version": {
@@ -101,10 +122,13 @@ func TestGetGVKs(t *testing.T) {
 				Versions:  nil,
 				Resources: []string{"horizontalpodautoscalers"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "autoscaling",
-				Version: "v2",
-				Kind:    "HorizontalPodAutoscaler",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v2",
+					Kind:    "HorizontalPodAutoscaler",
+				},
 			}},
 		},
 		"wildcard-version": {
@@ -113,14 +137,20 @@ func TestGetGVKs(t *testing.T) {
 				Versions:  []string{"*"},
 				Resources: []string{"horizontalpodautoscalers"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "autoscaling",
-				Version: "v2",
-				Kind:    "HorizontalPodAutoscaler",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v2",
+					Kind:    "HorizontalPodAutoscaler",
+				},
 			}, {
-				Group:   "autoscaling",
-				Version: "v1",
-				Kind:    "HorizontalPodAutoscaler",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "autoscaling",
+					Version: "v1",
+					Kind:    "HorizontalPodAutoscaler",
+				},
 			}},
 		},
 		"wildcard-version-inexistent-group": {
@@ -140,18 +170,27 @@ func TestGetGVKs(t *testing.T) {
 				// frontendconfigs only exist in v1beta1, managedcertificates only in v1.
 				Resources: []string{"serviceattachments", "frontendconfigs", "managedcertificates"},
 			},
-			expectedGVKs: []schema.GroupVersionKind{{
-				Group:   "networking.gke.io",
-				Version: "v1",
-				Kind:    "ServiceAttachment",
+			expectedGVKs: []GroupVersionKind{{
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "networking.gke.io",
+					Version: "v1",
+					Kind:    "ServiceAttachment",
+				},
 			}, {
-				Group:   "networking.gke.io",
-				Version: "v1beta1",
-				Kind:    "FrontendConfig",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "networking.gke.io",
+					Version: "v1beta1",
+					Kind:    "FrontendConfig",
+				},
 			}, {
-				Group:   "networking.gke.io",
-				Version: "v1",
-				Kind:    "ManagedCertificate",
+				PreferredVersion: "v1",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "networking.gke.io",
+					Version: "v1",
+					Kind:    "ManagedCertificate",
+				},
 			}},
 		},
 	}
@@ -211,6 +250,10 @@ func (fd *fakeDiscovery) versionsForGroup(group string) ([]string, error) {
 		return nil, newNotFoundError(schema.GroupVersionResource{Group: group})
 	}
 	return versions, nil
+}
+
+func (fd *fakeDiscovery) findGroupPreferredVersion(group string) (string, error) {
+	return "v1", nil
 }
 
 func (fd *fakeDiscovery) findGVK(gvr schema.GroupVersionResource) (schema.GroupVersionKind, error) {

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -82,24 +82,24 @@ func TestHelmChartConfig(t *testing.T) {
 		},
 	}
 	// these are just *some* GVKs, not all of them.
-	expectedGVKs := [][]schema.GroupVersionKind{
+	expectedGVKs := [][]GroupVersionKind{
 		{
-			{Group: "", Version: "v1", Kind: "Pod"},
-			{Group: "", Version: "v1", Kind: "Service"},
-			{Group: "", Version: "v1", Kind: "Namespace"},
-			{Group: "", Version: "v1", Kind: "ReplicationController"},
-			{Group: "", Version: "v1", Kind: "Node"},
-			{Group: "", Version: "v1", Kind: "ConfigMap"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, PreferredVersion: "v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}, PreferredVersion: "v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, PreferredVersion: "v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}, PreferredVersion: "v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}, PreferredVersion: "v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, PreferredVersion: "v1"},
 		}, {
-			{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
-			{Group: "apps", Version: "v1", Kind: "DaemonSet"},
-			{Group: "apps", Version: "v1", Kind: "Deployment"},
-			{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}, PreferredVersion: "apps/v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}, PreferredVersion: "apps/v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, PreferredVersion: "apps/v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}, PreferredVersion: "apps/v1"},
 		}, {
-			{Group: "batch", Version: "v1", Kind: "CronJob"},
-			{Group: "batch", Version: "v1", Kind: "Job"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}, PreferredVersion: "batch/v1"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}, PreferredVersion: "batch/v1"},
 		}, {
-			{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+			{GroupVersionKind: schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"}, PreferredVersion: "networking.k8s.io/v1"},
 		},
 		// we don't deploy any CRDs, so we can't check them.
 		// TODO: should we?
@@ -133,7 +133,7 @@ func TestHelmChartConfig(t *testing.T) {
 		t.Fatalf("could not get discovery client: %v", err)
 	}
 
-	var allGVKs [][]schema.GroupVersionKind
+	var allGVKs [][]GroupVersionKind
 	for _, st := range cfg.Scanning.Types {
 		gvks, err := st.GetGVKs(d, zap.New(zap.UseDevMode(true)))
 		if err != nil {

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -67,18 +67,19 @@ func TestHelmChartConfig(t *testing.T) {
 			RequeueAfter: metav1.Duration{Duration: 6 * time.Hour},
 			Types: []ScanType{{
 				APIGroups:  []string{""},
-				Versions:   []string{"v1"},
+				Versions:   []string{"*"},
 				Resources:  []string{"pods", "services", "namespaces", "replicationcontrollers", "nodes", "configmaps"},
 				Namespaces: []string{},
 			}, {
 				APIGroups: []string{"batch"},
+				Versions:  []string{"*"},
 				Resources: []string{"cronjobs", "jobs"},
 			}},
 		},
 		Egress: &Egress{
 			SnykServiceAccountToken: testToken,
 			HTTPClientTimeout:       metav1.Duration{Duration: 5 * time.Second},
-			SnykAPIBaseURL:          "https://app.dev.snyk.io",
+			SnykAPIBaseURL:          "https://api.snyk.io",
 		},
 	}
 	// these are just *some* GVKs, not all of them.

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,7 @@ func TestController(t *testing.T) {
 			RequeueAfter: metav1.Duration{Duration: time.Second},
 		},
 		OrganizationID: orgID,
+		MetricsAddress: "localhost:9091",
 	}
 
 	if err := waitForAPI(ctx, c); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -232,7 +232,7 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, orgID string, deletedAt *metav1.Time) error {
+func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error {
 	rID := newResourceID(obj, orgID)
 
 	if deletedAt == nil {


### PR DESCRIPTION


**feat: send preferred version**

As well being able to send multiple apiVersion representations of the
same resources, also include the preferred version of each resource in
the payload to the backend.



**chore: only bind loopback iface in a test**

To avoid mac security warnings on every test run.



**chore: change default config to scan all versions**




---

Coupled to https://github.com/snyk/kubernetes-resource-store/pull/63 - these should be merged together when ready.