### PR TITLE
fix: do not crash on inexistent group

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -263,7 +263,7 @@ func (d *discoveryHelper) versionsForGroup(apiGroup string) ([]string, error) {
 			return versions, nil
 		}
 	}
-	return nil, fmt.Errorf("group %v does not exist", apiGroup)
+	return nil, newNotFoundError(schema.GroupVersionResource{Group: apiGroup})
 }
 
 // findGVK returns the GroupVersionKind for the given GVR.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -153,10 +153,17 @@ func TestGetGVKs(t *testing.T) {
 				Kind:    "Pod",
 			}},
 		},
-		"inexistent-group": {
+		"inexistent-group-with-version-set": {
 			scanType: ScanType{
 				APIGroups: []string{"custom-crd.io"},
 				Versions:  []string{"v1"},
+				Resources: []string{"foo"},
+			},
+			expectedGVKs: nil,
+		},
+		"inexistent-group-with-no-version": {
+			scanType: ScanType{
+				APIGroups: []string{"custom-crd.io"},
 				Resources: []string{"foo"},
 			},
 			expectedGVKs: nil,


### PR DESCRIPTION
This commit fixes the config-parser to not return an error if a group does not exist. So far we didn't return a Kubernetes "NotFound" error, but a custom one, which meant that the matching didn't work.

We "fixed" this for the test-mock once already, but never fixed the actual implementation...

Notes:
- The added tests-case actually also passes without the fix, because the tests use the discovery mock. 
- We might want to test the discovery-mock separately. I'll add that in a separate PR tomorrow.
- Maybe there's a way to template the Helm configmap and make sure that that can be parsed successfully as well. That would be a pretty cool integration test...