### PR TITLE
test: helm chart config map parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/kubectl v0.26.0
 	sigs.k8s.io/controller-runtime v0.14.4
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -153,7 +154,6 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/kubectl v0.26.0 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	oras.land/oras-go v1.2.2 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/helm/kubernetes-scanner/templates/serviceaccount.yaml
+++ b/helm/kubernetes-scanner/templates/serviceaccount.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -1,0 +1,169 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/snyk/kubernetes-scanner/build/helmreleaser/git"
+	"github.com/snyk/kubernetes-scanner/build/helmreleaser/helm"
+	"github.com/snyk/kubernetes-scanner/internal/test"
+)
+
+func TestHelmChartConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("not spawning API Server in the interest of time")
+	}
+
+	cm, err := getHelmChartConfigMap("//helm/kubernetes-scanner", map[string]interface{}{
+		"secretName":     "snyk-service-account",
+		"organizationID": "umbrella-corp",
+	})
+	if err != nil {
+		t.Fatalf("could not load config from helm chart: %v", err)
+	}
+	config, ok := cm.Data["config.yaml"]
+	if !ok {
+		t.Fatalf("configMap does not contain `config.yaml`")
+	}
+
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatalf("could not create temporary file for testing: %v", err)
+	}
+
+	const testToken = "my-token"
+	t.Setenv("SNYK_SERVICE_ACCOUNT_TOKEN", testToken)
+
+	expected := &Config{
+		MetricsAddress: ":8080",
+		ClusterName:    "default",
+		OrganizationID: "umbrella-corp",
+		Scanning: Scan{
+			RequeueAfter: metav1.Duration{Duration: 6 * time.Hour},
+			Types: []ScanType{{
+				APIGroups:  []string{""},
+				Versions:   []string{"v1"},
+				Resources:  []string{"pods", "services", "namespaces", "replicationcontrollers", "nodes", "configmaps"},
+				Namespaces: []string{},
+			}, {
+				APIGroups: []string{"batch"},
+				Resources: []string{"cronjobs", "jobs"},
+			}},
+		},
+		Egress: &Egress{
+			SnykServiceAccountToken: testToken,
+			HTTPClientTimeout:       metav1.Duration{Duration: 5 * time.Second},
+			SnykAPIBaseURL:          "https://app.dev.snyk.io",
+		},
+	}
+	// these are just *some* GVKs, not all of them.
+	expectedGVKs := [][]schema.GroupVersionKind{
+		{
+			{Group: "", Version: "v1", Kind: "Pod"},
+			{Group: "", Version: "v1", Kind: "Service"},
+			{Group: "", Version: "v1", Kind: "Namespace"},
+			{Group: "", Version: "v1", Kind: "ReplicationController"},
+			{Group: "", Version: "v1", Kind: "Node"},
+			{Group: "", Version: "v1", Kind: "ConfigMap"},
+		}, {
+			{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+			{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+			{Group: "apps", Version: "v1", Kind: "Deployment"},
+			{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+		}, {
+			{Group: "batch", Version: "v1", Kind: "CronJob"},
+			{Group: "batch", Version: "v1", Kind: "Job"},
+		}, {
+			{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		},
+		// we don't deploy any CRDs, so we can't check them.
+		// TODO: should we?
+	}
+
+	restCfg := test.SetupEnv(t)
+	if err := flag.Set("kubeconfig", test.GenerateKubeconfig(t, restCfg)); err != nil {
+		t.Fatalf("could not set kubeconfig flag: %v", err)
+	}
+	flag.Parse()
+
+	if _, err := f.Write([]byte(config)); err != nil {
+		t.Fatalf("error writing config file: %v", err)
+	}
+
+	cfg, err := Read(f.Name())
+	if err != nil {
+		t.Fatalf("could not read config: %v", err)
+	}
+
+	for _, typ := range expected.Scanning.Types {
+		require.Contains(t, cfg.Scanning.Types, typ)
+	}
+	require.Equal(t, expected.Scanning.RequeueAfter, cfg.Scanning.RequeueAfter)
+	require.Equal(t, expected.MetricsAddress, cfg.MetricsAddress)
+	require.Equal(t, expected.ProbeAddress, cfg.ProbeAddress)
+	require.Equal(t, expected.Egress, cfg.Egress)
+
+	d, err := cfg.Discovery()
+	if err != nil {
+		t.Fatalf("could not get discovery client: %v", err)
+	}
+
+	var allGVKs [][]schema.GroupVersionKind
+	for _, st := range cfg.Scanning.Types {
+		gvks, err := st.GetGVKs(d, zap.New(zap.UseDevMode(true)))
+		if err != nil {
+			t.Fatalf("could not get GVKs: %v", err)
+		}
+		// gvks might be nil, but we don't care.
+		allGVKs = append(allGVKs, gvks)
+	}
+
+	for _, expectedGVK := range expectedGVKs {
+		require.Contains(t, allGVKs, expectedGVK)
+	}
+}
+
+func getHelmChartConfigMap(path string, values map[string]interface{}) (*corev1.ConfigMap, error) {
+	p, err := git.ResolvePath(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve git path: %w", err)
+	}
+
+	objs, err := helm.TemplateChart(p, values)
+	if err != nil {
+		return nil, fmt.Errorf("could not template chart: %w", err)
+	}
+
+	for _, obj := range objs {
+		if cm, ok := obj.(*corev1.ConfigMap); ok {
+			return cm, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no config file in templated manifests found")
+}


### PR DESCRIPTION
This commit changes the existing "RealAPI" config test from using an inline config to using the config that we template in the Helm chart.

To achieve this, we introduce a "TemplateChart" function that templates a Helm chart at a given path with some values and returns the rendered manifests. We then extract the ConfigMap from there and write it to a file, which we then run our tests on.

The test assures that some default types from the Kubernetes APIs are present. It does not test any CRDs, as we don't register any and as such the GVK-lookup would fail.