### PR TITLE
Crush bugs

### DIFF
--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -52,9 +52,12 @@ config:
         # multiple to scan for multiple versions at once.
         versions: ["*"]
         # an empty list (or not defining this key at all) does not limit
-        # scanning to any namespace. E.g. "namespaces: ["default"]" would limit
-        # the scanner to only scan for pods in the default namespace.
-        namespaces: []
+        # scanning to any namespace.
+        # Limit scanning to certain namespaces. An empty list limits scanning
+        # to only cluster-scoped resources.
+        # E.g. "namespaces: ["default"]" would limit the scanner to only scan
+        # for pods in the default namespace.
+        # namespaces: []
       - apiGroups: ["rbac.authorization.k8s.io"]
         versions: ["*"]
         resources:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,9 +161,10 @@ type ScanType struct {
 	// Versions is an optional field to specify which exact versions should be scanned. If unset,
 	// the scanner will use the API Server's preferred version.
 	Versions []string `json:"versions"`
-	// Namespaces allows to restrict scanning to specific namespaces. An empty list means all
-	// namespaces.
-	Namespaces []string `json:"namespaces"`
+	// Namespaces allows to restrict scanning to specific namespaces. An empty list means no
+	// namespaces. Omit to scan resources in all namespaces. Does not affect the scanning of
+	// cluster-scoped resources.
+	Namespaces []string `json:"namespaces,omitempty"`
 }
 
 // GetGVKs returns all the GVKs that are defined in the ScanType and are available on the server.

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -67,10 +67,9 @@ func TestHelmChartConfig(t *testing.T) {
 		Scanning: Scan{
 			RequeueAfter: metav1.Duration{Duration: 6 * time.Hour},
 			Types: []ScanType{{
-				APIGroups:  []string{""},
-				Versions:   []string{"*"},
-				Resources:  []string{"pods", "services", "namespaces", "replicationcontrollers", "nodes", "configmaps"},
-				Namespaces: []string{},
+				APIGroups: []string{""},
+				Versions:  []string{"*"},
+				Resources: []string{"pods", "services", "namespaces", "replicationcontrollers", "nodes", "configmaps"},
 			}, {
 				APIGroups: []string{"batch"},
 				Versions:  []string{"*"},

--- a/main.go
+++ b/main.go
@@ -155,7 +155,9 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	)
 	log.Info("reconciling resource")
 
-	if r.namespaces != nil && !slices.Contains(r.namespaces, req.Namespace) {
+	// as long as r.namespaces is set, we want to check it. It might be 0-length, which will skip
+	// all namespaced resources. This is expected behavior.
+	if req.Namespace != "" && r.namespaces != nil && !slices.Contains(r.namespaces, req.Namespace) {
 		// don't set the requeueafter, we don't need it.
 		log.V(1).Info("skipping resources as namespace is ignored")
 		return ctrl.Result{}, nil

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/snyk/kubernetes-scanner/internal/config"
 	controllertest "github.com/snyk/kubernetes-scanner/internal/test"
@@ -48,6 +50,8 @@ func TestController(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	test := newTest(t)
 	c, err := client.New(test.config, client.Options{Scheme: scheme.Scheme})

--- a/main_test.go
+++ b/main_test.go
@@ -181,6 +181,15 @@ func newTest(t *testing.T) test {
 					}},
 				},
 			},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-node",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Node",
+					APIVersion: "v1",
+				},
+			},
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "normal-secret",
@@ -207,7 +216,7 @@ func newTest(t *testing.T) test {
 		},
 		types: []config.ScanType{{
 			APIGroups: []string{""},
-			Resources: []string{"secrets", "pods"},
+			Resources: []string{"secrets", "pods", "nodes"},
 			Versions:  []string{"v1"},
 		}, {
 			APIGroups:  []string{""},


### PR DESCRIPTION


**test: node scraping**

This commit adds a test to ensure that node scanning works. And more
generally, that we can scan cluster-scoped resources - we didn't have
any in the test so far.



**test: log**

We actually need some log output in tests to tell what's going on.



**fixup! test: node scraping**




**feat: fix behavior & documentation on namespaces setting**

This commit fixes the documentation on the `namespaces` key in the scan
types. The comment previously said that a 0-length list (`[]`) has the
same behavior as `null`. However, that wasn't actually true, and we even
had this bug in the Helm chart.

To fix this, I could have also changed the code to treat null and empty
as the same. However, I decided to differentiate it so that an empty
list can be used to skip all namespaced resources: by setting `[]`, it
will skip all namespaces and thus only reconcile cluster-scoped
resources. While this isn't particularly useful today, this could change
if we'd ever introduce the `resources: ["*"]` setting / feature.

(One could argue that we could have changed the code at that point as
well, but that would have introduced a breaking change, which we can
avoid now).
