### PR TITLE
[TIKI-90] custom podmonitor labels

### DIFF
--- a/helm/kubernetes-scanner/templates/prom-pod-monitor.yaml
+++ b/helm/kubernetes-scanner/templates/prom-pod-monitor.yaml
@@ -21,6 +21,9 @@ metadata:
   name: {{ include "kubernetes-scanner.fullname" . }}
   labels:
     {{- include "kubernetes-scanner.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.podMonitor.labels -}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -226,3 +226,4 @@ affinity: {}
 prometheus:
   podMonitor:
     enabled: false
+    labels: {}


### PR DESCRIPTION


**test: support decoding CRDs from Helm charts**

This commit adds support for arbitrary CRDs in the `helm.TemplateChart`
function, returning them as `unstructured.Unstructured` resources. This
way, we can at least do some checks against CRDs, and not just error out
on them.



**feat: support separate podMonitor labels**

This commit adds support for separate podMonitor labels, so that users
of the Helm chart can add arbitrary labels to their podMonitor.



**test: additional labels for podMonitor**

This commit adds a small test for the podMonitor in the Helm chart,
making sure that we can actually pass in some labels.

I added this test because working on the Helm chart I got it wrong at
first, and the test made it easier to be sure that it works...

The "downside" of this is that we now not test not creating the
podMonitor (that's probably not that bad) and not test not adding labels
(sorry for the many nots)...

I think with labels is the most complicated use-case, so probably the
thing worth testing, but I also tested no labels manually...
