### PR TITLE
feat: allow custom pod labels in Helm chart

### DIFF
--- a/helm/kubernetes-scanner/templates/deployment.yaml
+++ b/helm/kubernetes-scanner/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       {{- end }}
       labels:
         {{- include "kubernetes-scanner.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -185,6 +185,7 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext:
   fsGroup: 2000


### PR DESCRIPTION
This commit extends the Helm chart by a `podLabels` field that will be passed through the Helm chart into the Deployment's pod template's labels.

It has been tested locally, rendering the chart with both a label set and no labels set (using the default value).