### PR TITLE
[TIKI-97] feat: backend retry observability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/go-git/go-git/v5 v5.6.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-github/v49 v49.0.0
+	github.com/prometheus/client_golang v1.14.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
@@ -109,8 +111,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,9 @@ import (
 type Config struct {
 	Scanning       Scan   `json:"scanning"`
 	MetricsAddress string `json:"metricsAddress"`
-	ProbeAddress   string `json:"probeAddress"`
+	// MetricsNamespace defines the namespace that will be used for the prometheus metrics.
+	MetricsNamespace string `json:"metricsNamespace"`
+	ProbeAddress     string `json:"probeAddress"`
 	// OrganizationID is the snyk organization ID where data should be routed to.
 	OrganizationID string `json:"organizationID"`
 

--- a/main.go
+++ b/main.go
@@ -17,11 +17,10 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"time"
-
 	"flag"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/snyk/kubernetes-scanner/build"
 	"github.com/snyk/kubernetes-scanner/internal/backend"
@@ -39,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -71,7 +71,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := setupController(cfg, backend.New(cfg.ClusterName, cfg.Egress))
+	mgr, err := setupController(cfg, backend.New(cfg.ClusterName, cfg.Egress, ctrlmetrics.Registry))
 	if err != nil {
 		setupLog.Error(err, "unable to setup controller")
 		os.Exit(1)


### PR DESCRIPTION
**feat: backend retry observability**

This commit adds two custom metrics to the controller-runtime's builtin
prometheus registry (which is being served on the metrics-endpoint).

`kubernetes_scanner_backend_retries` is a histogram that counts the
number of retries necessary to reconcile a resource, partitioned by HTTP
status code.

`kubernetes_scanner_backend_oldest_failure` is a timestamp disguised as
a gauge that shows the age of the oldest failure, e.g. it tracks the
oldest stale resource.

