### PR TITLE
chore: correlate information on logs TIKI-95

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-git/go-git/v5 v5.6.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-github/v49 v49.0.0
+	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.1
@@ -71,7 +72,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"io"
 	"math"
 	"net/http"
@@ -65,11 +64,10 @@ func New(clusterName string, cfg *config.Egress, reg prometheus.Registerer) *Bac
 
 const contentTypeJSON = "application/vnd.api+json"
 
-func (b *Backend) Upsert(ctx context.Context, obj client.Object, preferredVersion string, orgID string, deletedAt *metav1.Time) (string, error) {
-	requestID := uuid.New().String()
+func (b *Backend) Upsert(ctx context.Context, requestID string, obj client.Object, preferredVersion string, orgID string, deletedAt *metav1.Time) error {
 	body, err := b.newPostBody(obj, preferredVersion, deletedAt)
 	if err != nil {
-		return requestID, fmt.Errorf("could not construct request body: %w", err)
+		return fmt.Errorf("could not construct request body: %w", err)
 	}
 
 	endpoint := fmt.Sprintf("%s/hidden/orgs/%s/kubernetes_resources?version=2023-02-20~experimental",
@@ -77,7 +75,7 @@ func (b *Backend) Upsert(ctx context.Context, obj client.Object, preferredVersio
 
 	req, err := http.NewRequest(http.MethodPost, endpoint, body)
 	if err != nil {
-		return requestID, fmt.Errorf("could not construct request: %w", err)
+		return fmt.Errorf("could not construct request: %w", err)
 	}
 	req.Header.Add("Content-Type", contentTypeJSON)
 	req.Header.Add("Authorization", "token "+b.authorizationKey)
@@ -86,7 +84,7 @@ func (b *Backend) Upsert(ctx context.Context, obj client.Object, preferredVersio
 	resp, err := b.client.Do(req.WithContext(ctx))
 	if err != nil {
 		b.recordFailure(ctx, 0, obj.GetUID())
-		return requestID, fmt.Errorf("could not post resource: %w", err)
+		return fmt.Errorf("could not post resource: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -94,13 +92,13 @@ func (b *Backend) Upsert(ctx context.Context, obj client.Object, preferredVersio
 		body, err := io.ReadAll(resp.Body)
 		b.recordFailure(ctx, resp.StatusCode, obj.GetUID())
 		if err != nil {
-			return requestID, fmt.Errorf("got non-20x HTTP code %v and could not read body: %w", resp.StatusCode, err)
+			return fmt.Errorf("got non-20x HTTP code %v and could not read body: %w", resp.StatusCode, err)
 		}
-		return requestID, fmt.Errorf("got non-20x exit code %v with body %s", resp.StatusCode, body)
+		return fmt.Errorf("got non-20x exit code %v with body %s", resp.StatusCode, body)
 	}
 
 	b.recordSuccess(ctx, obj.GetUID())
-	return requestID, nil
+	return nil
 }
 
 // for testing.

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -68,14 +68,12 @@ func TestBackend(t *testing.T) {
 		SnykAPIBaseURL:          ts.URL,
 		SnykServiceAccountToken: testToken,
 	}, prometheus.NewPedanticRegistry())
-	requestID, err := b.Upsert(ctx, pod, "v1", orgID, nil)
+	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, requestID)
 
 	tu.expectDeletion = true
-	requestID, err = b.Upsert(ctx, pod, "v1", orgID, &metav1.Time{Time: now().Local()})
+	err = b.Upsert(ctx, "req-id", pod, "v1", orgID, &metav1.Time{Time: now().Local()})
 	require.NoError(t, err)
-	require.NotEmpty(t, requestID)
 
 }
 
@@ -92,7 +90,7 @@ func TestBackendErrorHandling(t *testing.T) {
 		SnykServiceAccountToken: testToken,
 	}, prometheus.NewPedanticRegistry())
 
-	_, err := b.Upsert(ctx, pod, "v1", orgID, nil)
+	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.Error(t, err)
 }
 
@@ -109,16 +107,14 @@ func TestMetricsFromBackend(t *testing.T) {
 		SnykServiceAccountToken: testToken,
 	}, prometheus.NewPedanticRegistry())
 
-	requestID, err := b.Upsert(ctx, pod, "v1", orgID, nil)
+	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.Error(t, err)
-	require.NotEmpty(t, requestID)
 	require.Equal(t, uint8(1), b.failures[pod.UID].retries)
 	require.Equal(t, 400, b.failures[pod.UID].code)
 
 	tu.statusCodeToReturn = 0
-	requestID, err = b.Upsert(ctx, pod, "v1", orgID, nil)
+	err = b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, requestID)
 	_, ok := b.failures[pod.UID]
 	require.False(t, ok)
 }

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/google/uuid"
 	"os"
 	"time"
 
@@ -144,17 +145,19 @@ type store interface {
 	// Upsert an object into the store. If the deletedAt time is non-zero, a deletion-event should
 	// be recorded. Otherwise, the store should simply ensure that the object saved in the store
 	// matches the one we're providing.
-	Upsert(ctx context.Context, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) (string, error)
+	Upsert(ctx context.Context, requestID string, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
+	requestID := uuid.New().String()
 	log := log.FromContext(ctx).WithValues(
 		"group", r.gvk.Group,
 		"version", r.gvk.Version,
 		"kind", r.gvk.Kind,
 		"name", req.Name,
 		"namespace", req.Namespace,
+		"request_id", requestID,
 	)
 	log.Info("reconciling resource")
 
@@ -178,18 +181,16 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		obj.SetNamespace(req.Namespace)
 		// don't requeue after deletion.
 		now := metav1.Now()
-		requestID, err := r.store.Upsert(ctx, obj, r.gvk.PreferredVersion, r.orgID, &now)
+		err := r.store.Upsert(ctx, requestID, obj, r.gvk.PreferredVersion, r.orgID, &now)
 		if err != nil {
-			log.WithValues("request_id", requestID).
-				Error(err, "could not publish to store")
+			log.Error(err, "could not publish deletion to store")
 		}
 		return ctrl.Result{}, err
 	}
 
-	requestID, err := r.store.Upsert(ctx, obj, r.gvk.PreferredVersion, r.orgID, nil)
+	err := r.store.Upsert(ctx, requestID, obj, r.gvk.PreferredVersion, r.orgID, nil)
 	if err != nil {
-		log.WithValues("request_id", requestID).
-			Error(err, "could not publish to store")
+		log.Error(err, "could not publish upsert to store")
 	}
 
 	return ctrl.Result{RequeueAfter: r.requeueAfter}, err

--- a/main_test.go
+++ b/main_test.go
@@ -246,7 +246,7 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error {
+func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) (string, error) {
 	rID := newResourceID(obj, orgID)
 
 	if deletedAt == nil {
@@ -255,7 +255,7 @@ func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVe
 		f.deleted <- rID
 	}
 
-	return nil
+	return "uid", nil
 }
 
 type reconciliationEvents struct {

--- a/main_test.go
+++ b/main_test.go
@@ -246,7 +246,7 @@ func newFakeBackend() *fakeBackend {
 	}
 }
 
-func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) (string, error) {
+func (f *fakeBackend) Upsert(ctx context.Context, requestID string, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error {
 	rID := newResourceID(obj, orgID)
 
 	if deletedAt == nil {
@@ -255,7 +255,7 @@ func (f *fakeBackend) Upsert(ctx context.Context, obj client.Object, preferredVe
 		f.deleted <- rID
 	}
 
-	return "uid", nil
+	return nil
 }
 
 type reconciliationEvents struct {


### PR DESCRIPTION


**chore: correlate information on logs TIKI-95**

backend generates a snyk-request-id and returns it to the app
so the requestID can be logged and correlated with errors on the backend

