### PR TITLE
[TIKI-97] Assorted observability improvements

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -383,6 +383,15 @@ func TestMetricsOldest(t *testing.T) {
 	})
 }
 
+func TestMetricsErrors(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	m := newMetrics(registry)
+	m.recordFailure(context.Background(), 500, "a-uid")
+	requireMetric(t, registry, "kubernetes_scanner_backend_errors_total", func(t *testing.T, metric *promclient.Metric) {
+		require.Equal(t, 1.0, metric.Counter.GetValue())
+	})
+}
+
 // requireMetrics requires the given metric to be present in the registry and pass the requireFn.
 func requireMetric(t *testing.T, registry prometheus.Gatherer, metricName string,
 	requireFn func(*testing.T, *promclient.Metric),

--- a/main.go
+++ b/main.go
@@ -49,7 +49,9 @@ func main() {
 		configFile   = flag.String("config", "/etc/kubernetes-scanner/config.yaml", "defines the location of the config file")
 		showLicenses = flag.Bool("licenses", false, "show license information")
 		logOpts      = zap.Options{
-			Development: true,
+			// The various `zap-` flags in this struct definition can be passed to
+			// this program due to the call to BindFlags() below. None of this is
+			// exposed through helm, yet - a decision we might revisit.
 		}
 	)
 


### PR DESCRIPTION


**chore: update some metric descriptions**




**fix: backend error counter metric**

So that we can plot error rate by backend status code.



**fix: controller-runtime production logging**

Stop hardcoding development logging. This isn't configurable through the
config file or helm, but can be toggled with the standard `zap-` flags.

