### PR TITLE
Fix/deletion metrics

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -83,7 +84,7 @@ func (b *Backend) Upsert(ctx context.Context, requestID string, obj client.Objec
 
 	resp, err := b.client.Do(req.WithContext(ctx))
 	if err != nil {
-		b.recordFailure(ctx, 0, obj.GetUID())
+		b.recordFailure(ctx, 0, obj)
 		return fmt.Errorf("could not post resource: %w", err)
 	}
 	defer resp.Body.Close()
@@ -93,7 +94,7 @@ func (b *Backend) Upsert(ctx context.Context, requestID string, obj client.Objec
 			fmt.Errorf("received HTTP response code %d", resp.StatusCode),
 			"error response HTTP headers",
 		)
-		b.recordFailure(ctx, resp.StatusCode, obj.GetUID())
+		b.recordFailure(ctx, resp.StatusCode, obj)
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("got non-20x HTTP code %v and could not read body: %w", resp.StatusCode, err)
@@ -101,7 +102,7 @@ func (b *Backend) Upsert(ctx context.Context, requestID string, obj client.Objec
 		return fmt.Errorf("got non-20x exit code %v with body %s", resp.StatusCode, body)
 	}
 
-	b.recordSuccess(ctx, obj.GetUID())
+	b.recordSuccess(ctx, obj)
 	return nil
 }
 
@@ -151,9 +152,26 @@ type resource struct {
 	DeletedAt        *metav1.Time  `json:"deleted_at,omitempty"`
 }
 
+// resourceIdentifier identifies a specific resource. This cannot be done through
+// the UID because the UID is absent on delete requests.
+type resourceIdentifier struct {
+	schema.GroupVersionKind
+	types.NamespacedName
+}
+
+func newResourceID(from client.Object) resourceIdentifier {
+	return resourceIdentifier{
+		GroupVersionKind: from.GetObjectKind().GroupVersionKind(),
+		NamespacedName: types.NamespacedName{
+			Name:      from.GetName(),
+			Namespace: from.GetNamespace(),
+		},
+	}
+}
+
 type metrics struct {
 	sync.Mutex
-	failures map[types.UID]*upsertFailure
+	failures map[resourceIdentifier]*upsertFailure
 	oldest   *int64
 
 	retries                *prometheus.HistogramVec
@@ -167,7 +185,7 @@ var retriesBuckets = []float64{1, 2, 3, 5, 10, 50}
 
 func newMetrics(registry prometheus.Registerer) *metrics {
 	m := &metrics{
-		failures: make(map[types.UID]*upsertFailure),
+		failures: make(map[resourceIdentifier]*upsertFailure),
 		oldest:   nil,
 
 		retries: prometheus.NewHistogramVec(
@@ -214,14 +232,16 @@ func newMetrics(registry prometheus.Registerer) *metrics {
 	return m
 }
 
-func (m *metrics) recordFailure(ctx context.Context, code int, uid types.UID) {
+func (m *metrics) recordFailure(ctx context.Context, code int, obj client.Object) {
 	m.Lock()
 	defer m.Unlock()
+
+	resID := newResourceID(obj)
 
 	m.errors.With(prometheus.Labels{
 		"code": strconv.Itoa(code),
 	}).Inc()
-	if f, ok := m.failures[uid]; ok {
+	if f, ok := m.failures[resID]; ok {
 		f.retries++
 		f.code = code
 	} else {
@@ -231,7 +251,7 @@ func (m *metrics) recordFailure(ctx context.Context, code int, uid types.UID) {
 			added:   &now,
 			retries: 1,
 		}
-		m.failures[uid] = fail
+		m.failures[resID] = fail
 		m.retriesTotal.Inc()
 		if m.oldest == nil {
 			m.oldestFailureTimestamp.Set(float64(now))
@@ -241,11 +261,12 @@ func (m *metrics) recordFailure(ctx context.Context, code int, uid types.UID) {
 	}
 }
 
-func (m *metrics) recordSuccess(ctx context.Context, uid types.UID) {
+func (m *metrics) recordSuccess(ctx context.Context, obj client.Object) {
 	m.Lock()
 	defer m.Unlock()
 
-	fail, ok := m.failures[uid]
+	resID := newResourceID(obj)
+	fail, ok := m.failures[resID]
 	if !ok {
 		return
 	}
@@ -254,18 +275,18 @@ func (m *metrics) recordSuccess(ctx context.Context, uid types.UID) {
 		"code": strconv.Itoa(fail.code),
 	}).Observe(float64(fail.retries))
 
-	delete(m.failures, uid)
+	delete(m.failures, resID)
 	m.retriesTotal.Dec()
 
 	// if we're deleting the oldest element, replace it with the new oldest element.
 	if m.oldest == fail.added {
 		m.oldest = nil
 
-		var newUID types.UID
-		for uid, newFail := range m.failures {
+		var newID resourceIdentifier
+		for id, newFail := range m.failures {
 			if m.oldest == nil || *m.oldest > *newFail.added {
 				m.oldest = newFail.added
-				newUID = uid
+				newID = id
 			}
 		}
 
@@ -274,7 +295,7 @@ func (m *metrics) recordSuccess(ctx context.Context, uid types.UID) {
 			log.FromContext(ctx).Info("removed oldest failure, no new ones")
 		} else {
 			m.oldestFailureTimestamp.Set(float64(*m.oldest))
-			log.FromContext(ctx).Info("replaced oldest failure", "new_oldest_failure", newUID)
+			log.FromContext(ctx).Info("replaced oldest failure", "new_oldest_failure", newID)
 		}
 	}
 }


### PR DESCRIPTION
**chore: use new resource identifier to store failures**

We've noticed that we have a dangling resource in our failure-map in the
dev-enviroment. The underlying reason for this dangling resource is
that the call to our API failed when the resource was being deleted, and
because it then never successfully reconciled again, it wasn't cleaned
up from the failure map.

The issue has two root causes:
1) When resources are in deletion and the API call fails, we
   `recordFailure` nonetheless. Because the resource will not be
    reconciled at all anymore, we have no chance to `recordSuccess`,
    so the resource will be abandoned and stay in the failure map
    forever.
2) We identify resources within that failure map by UID. Within a
   deletion call, that UID will be empty. As such, even if we wanted to
    remove a resource from the failure map at it's deletion call, we
    couldn't locate it in the map.

---
The first commit fixes 2), identifying resources by GVKNN instead of the UID.
This also lays the groundwork for fixing 1).

---

The second commit fixes 1): If we do not get a UID - which signals that the resource is being
deleted - we do not record the failure of the resource and instead call
`recordSuccess`. While technically the call wasn't a success,
`recordSuccess` does exactly what we want it to do: remove the resource
from the failure map and decrease any required counters.
