### PR TITLE
Logging improvement

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -93,6 +93,8 @@ func TestBackendErrorHandling(t *testing.T) {
 
 	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.Error(t, err)
+	require.IsType(t, &HTTPError{}, err)
+	require.Equal(t, 400, err.(*HTTPError).StatusCode)
 }
 
 func TestMetricsFromBackend(t *testing.T) {

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -112,7 +112,7 @@ func TestMetricsFromBackend(t *testing.T) {
 
 	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.Error(t, err)
-	require.Equal(t, uint8(1), b.failures[newResourceID(pod)].retries)
+	require.Equal(t, float64(1), b.failures[newResourceID(pod)].retries)
 	require.Equal(t, 400, b.failures[newResourceID(pod)].code)
 
 	tu.statusCodeToReturn = 0


### PR DESCRIPTION


**fix: improve logging & refactor**

This commit improves the logging, mainly adding "multi-field" values to
their own sub-field. Currently for example, all the resource info is
stored in top-level fields (`group`, `version`, `name` etc). For some
things this gets a bit hard to find, as there might be multiple
different `name`s in a log line once it's been parsed. This commit
instead moves this resource-information into `resource.<field>` to group
those together.

Same goes for the HTTP error information.



**refactor: improve metric handling**

This commit improves the metric handling a bit, creating shorter locks.



**refactor: extract helper functions**

This commit extracts two useful helper function from the main Reconcile
loop, as that has grown over time and could have used a refactor.
