### PR TITLE
feat: send data to multiple orgs [TIKI-50]

### DIFF
--- a/helm/kubernetes-scanner/templates/configmap.yaml
+++ b/helm/kubernetes-scanner/templates/configmap.yaml
@@ -29,7 +29,8 @@ data:
     probeAddress: ":{{ .Values.healthCheck.port }}"
     metricsAddress: ":{{ .Values.metrics.port }}"
     clusterName: {{ required "A clusterName is required" .Values.clusterName | quote }}
-    organizationID: {{ required "An organizationID is required" .Values.organizationID | quote }}
+    routes: 
+      {{- toYaml .Values.routes | nindent 6 }}
     scanning:
       requeueAfter: {{ .Values.config.scanning.requeueAfter }}
       types:

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -20,9 +20,39 @@
 
 enabled: true
 
-# MANDATORY: set cluster name & orgID
+# MANDATORY: set routes
+# Routes define which resources should be sent to which organizations.
+# It is required to provide at least one valid route to agent to be able to start
+# When using organization level service accounts, service account is authorized
+# to route data only for the organization it is created in.
+# When using group level service accounts, service account can route data to
+# all organizations under the created group.
+# This allows having a single installation of the kubernetes-scanner in a
+# cluster used by multiple organizations.
 #
-# organizationID: "setme"
+# Each route contains
+# * organizationID: Target organizationID for the resources
+# * clusterScopedResources: true if cluster resources should be routed for this organization
+# * namespaces: a list of namespaces. If * wildcard is used,
+# resources from all namespaces will be routed to organization
+#
+# An example routing configuration which will route
+# * All cluster resources and resources from all namespaces
+# to organization aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaa
+# * All resources from test-cluster-f and prod-cluster-f namespaces
+# to organization ffffffff-ffff-ffff-ffff-fffffffffffff
+#
+# routes:
+#  - organizationID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaa"
+#    clusterScopedResources: "true"
+#    namespaces:
+#      - "*"
+#  - organizationID: "ffffffff-ffff-ffff-ffff-fffffffffffff"
+#    clusterScopedResources: "false"
+#    namespaces:
+#      - "test-cluster-f"
+#      - "prod-cluster-f"
+
 
 # MANDATORY: clusterName is a friendly name for the cluster that this agent is
 # running on. For example "prod-us" or "dev-eu".

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -39,9 +39,15 @@ func TestHelmChartConfig(t *testing.T) {
 	}
 
 	values := map[string]interface{}{
-		"secretName":     "snyk-service-account",
-		"organizationID": "umbrella-corp",
-		"clusterName":    "default",
+		"secretName": "snyk-service-account",
+		"routes": []map[string]interface{}{
+			{
+				"organizationID":         "umbrella-corp",
+				"namespaces":             []string{"*"},
+				"clusterScopedResources": true,
+			},
+		},
+		"clusterName": "default",
 		// while this doesn't test the correctness of the podMonitor, it at least ensures that it
 		// can be decoded and is templated correctly.
 		"prometheus": map[string]interface{}{
@@ -107,7 +113,12 @@ func checkConfigMap(t *testing.T, cm *corev1.ConfigMap) {
 		MetricsAddress: ":8080",
 		ProbeAddress:   ":8081",
 		ClusterName:    "default",
-		OrganizationID: "umbrella-corp",
+		Routes: []Route{{
+			OrganizationID:         "umbrella-corp",
+			Namespaces:             []string{"*"},
+			ClusterScopedResources: true,
+		},
+		},
 		Scanning: Scan{
 			RequeueAfter: metav1.Duration{Duration: 6 * time.Hour},
 			Types: []ScanType{{


### PR DESCRIPTION


**feat: send data to multiple orgs [TIKI-50]**

We are sending data to multiple organisations based on the route configuration
provided in the helm chart now.

When an organization level service account is used, we can only route to
a single organization
But when a group level service account is used, we can route to multiple
organizations under the given group



**docs: routing configuration details**



[TIKI-50]: https://snyksec.atlassian.net/browse/TIKI-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ