### PR TITLE
[TIKI-86] refactors for smoke-test enablement

### DIFF
--- a/build/helmreleaser/helm/helm.go
+++ b/build/helmreleaser/helm/helm.go
@@ -16,27 +16,24 @@
 package helm
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/snyk/kubernetes-scanner/internal/test"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	helmchart "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/provenance"
 	helmrepo "helm.sh/helm/v3/pkg/repo"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/yaml"
 )
 
-// TemplateChart  templates the helm chart at the given path with the given values and returns the
+// TemplateChart templates the helm chart at the given path with the given values and returns the
 // decoded manifests. Note that CRDs cannot be decoded into their typed representation, and will
 // instead be returned as `unstructured.Unstructured` resources.
 func TemplateChart(path string, values map[string]interface{}) ([]runtime.Object, error) {
@@ -58,36 +55,7 @@ func TemplateChart(path string, values map[string]interface{}) ([]runtime.Object
 		return nil, fmt.Errorf("could not render helm chart: %w", err)
 	}
 
-	multidocReader := utilyaml.NewYAMLReader(bufio.NewReader(strings.NewReader(rel.Manifest)))
-	var objs []runtime.Object
-	for {
-		buf, err := multidocReader.Read()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, fmt.Errorf("could not read yaml document: %w", err)
-		}
-
-		// if we'd want to decode CRDs, we'd need to register the codecs.
-		obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(buf, nil, nil)
-		if err != nil {
-			// if we couldn't decode it with the core scheme, try decoding it into an ustructured
-			// type. For this, we first need to convert the YAML buffer to JSON, so that we can pass
-			// it to the unstructured decoder.
-			json, err := yaml.YAMLToJSON(buf)
-			if err != nil {
-				return nil, fmt.Errorf("could not re-encode manifest to JSON for fallback: %w", err)
-			}
-
-			obj, _, err = unstructured.UnstructuredJSONScheme.Decode(json, nil, nil)
-			if err != nil {
-				return nil, fmt.Errorf("could not decode resource: %w", err)
-			}
-		}
-		objs = append(objs, obj)
-	}
-	return objs, nil
+	return test.ParseKubernetesManifests(strings.NewReader(rel.Manifest))
 }
 
 type PackagedChart struct {

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -93,8 +93,9 @@ func TestBackendErrorHandling(t *testing.T) {
 
 	err := b.Upsert(ctx, "req-id", pod, "v1", orgID, nil)
 	require.Error(t, err)
-	require.IsType(t, &HTTPError{}, err)
-	require.Equal(t, 400, err.(*HTTPError).StatusCode)
+	var h *HTTPError
+	require.ErrorAs(t, err, &h)
+	require.Equal(t, 400, h.StatusCode)
 }
 
 func TestMetricsFromBackend(t *testing.T) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,265 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/snyk/kubernetes-scanner/internal/backend"
+	"github.com/snyk/kubernetes-scanner/internal/config"
+	"golang.org/x/exp/slices"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func New(cfg *config.Config, s Store) (manager.Manager, error) {
+	mgr, err := ctrl.NewManager(cfg.RestConfig, ctrl.Options{
+		Scheme:                 cfg.Scheme,
+		MetricsBindAddress:     cfg.MetricsAddress,
+		HealthProbeBindAddress: cfg.ProbeAddress,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to start manager: %w", err)
+	}
+
+	discovery, err := cfg.Discovery()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create discovery client: %w", err)
+	}
+
+	for _, scanType := range cfg.Scanning.Types {
+		// TODO: we depend on the logger being setup implicitly...
+		gvks, err := scanType.GetGVKs(discovery, log.Log)
+		if err != nil {
+			return nil, fmt.Errorf("could not get GVK: %w", err)
+		}
+
+		for _, gvk := range gvks {
+			if err := (&reconciler{
+				Reader:       mgr.GetClient(),
+				requeueAfter: cfg.Scanning.RequeueAfter.Duration,
+				Store:        s,
+				gvk:          gvk,
+				routes:       newResourceRoutes(cfg.Routes),
+				namespaces:   scanType.Namespaces,
+			}).SetupWithManager(mgr); err != nil {
+				return nil, fmt.Errorf("unable to create controller for GVK %v: %w", gvk, err)
+			}
+		}
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("unable to setup health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("unable to setup readiness check: %w", err)
+	}
+
+	return mgr, nil
+}
+
+type reconciler struct {
+	client.Reader
+	requeueAfter time.Duration
+	gvk          config.GroupVersionKind
+	Store
+	namespaces []string
+	routes     resourceRoutes
+}
+
+type resourceRoutes struct {
+	clusterResources []string
+	namespaceRoutes  map[string][]string
+}
+
+func newResourceRoutes(routes []config.Route) resourceRoutes {
+	cfg := resourceRoutes{
+		clusterResources: []string{},
+		namespaceRoutes:  map[string][]string{},
+	}
+
+	// Creating clusterResources with unique organizationIDs
+	// This de-duplicates possible misconfiguration with multiple ClusterScopedResources:true defined for same org
+	clusterRouteSet := map[string]bool{}
+	for _, route := range routes {
+		if route.ClusterScopedResources {
+			clusterRouteSet[route.OrganizationID] = true
+		}
+	}
+	for orgID := range clusterRouteSet {
+		cfg.clusterResources = append(cfg.clusterResources, orgID)
+	}
+
+	// Set with unique organizationIDs -> orgId -> namespace -> bool
+	namespaceRouteSet := map[string]map[string]bool{}
+	for _, route := range routes {
+		if namespaceRouteSet[route.OrganizationID] == nil {
+			namespaceRouteSet[route.OrganizationID] = map[string]bool{}
+		}
+		for _, ns := range route.Namespaces {
+			namespaceRouteSet[route.OrganizationID][ns] = true
+		}
+	}
+	// If there is a wildcard namespace route for an organization, do not store other namespace routes.
+	// This helps to de-duplicate if an organization was configured with ["*", "ns-1", ....]
+	for orgID, namespaceRoutes := range namespaceRouteSet {
+		if namespaceRoutes["*"] {
+			cfg.namespaceRoutes["*"] = append(cfg.namespaceRoutes["*"], orgID)
+		} else {
+			for ns := range namespaceRoutes {
+				cfg.namespaceRoutes[ns] = append(cfg.namespaceRoutes[ns], orgID)
+			}
+		}
+	}
+	return cfg
+}
+
+// targetOrganizations returns target organizations for given request based on config.Routes
+// Resources can be configured to be routed for zero or more organizations
+func (r resourceRoutes) targetOrganizations(req ctrl.Request) []string {
+	if req.Namespace == "" {
+		return r.clusterResources
+	}
+	// For namespaced resource, return all organizations with * and this specific namespace routes
+	return append(r.namespaceRoutes[req.Namespace], r.namespaceRoutes["*"]...)
+}
+
+type Store interface {
+	// Upsert an object into the store. If the deletedAt time is non-zero, a deletion-event should
+	// be recorded. Otherwise, the store should simply ensure that the object saved in the store
+	// matches the one we're providing.
+	Upsert(ctx context.Context, requestID string, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error
+}
+
+// newObject creates a new object for this reconciler with the reconciler's GVK and the requests
+// name & namespace. This is all we know about an object without getting it from the Kube API.
+func (r *reconciler) newObject(req ctrl.Request) client.Object {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(r.gvk.GroupVersionKind)
+	obj.SetName(req.Name)
+	obj.SetNamespace(req.Namespace)
+
+	return obj
+}
+
+// isIgnored returns true if the given request should be ignored / skipped due to the namespace of
+// the request and the setup of this reconciler.
+func (r *reconciler) isIgnored(req ctrl.Request) bool {
+	// as long as r.namespaces is set, we want to check it. It might be 0-length, which will skip
+	// all namespaced resources. This is expected behavior.
+	return req.Namespace != "" && r.namespaces != nil &&
+		!slices.Contains(r.namespaces, req.Namespace)
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx,
+		"resource", map[string]string{
+			"group":     r.gvk.Group,
+			"version":   r.gvk.Version,
+			"kind":      r.gvk.Kind,
+			"name":      req.Name,
+			"namespace": req.Namespace,
+		},
+	)
+	logger.Info("reconciling resource")
+
+	if r.isIgnored(req) {
+		logger.Info("skipping resources as namespace is ignored")
+		// Ignored resource means we don't need to requeue it either.
+		return ctrl.Result{}, nil
+	}
+
+	orgs := r.routes.targetOrganizations(req)
+	if len(orgs) == 0 {
+		logger.Info("skipping resources as namespace has no routes")
+		return ctrl.Result{}, nil
+	}
+
+	obj := r.newObject(req)
+	var deleted *metav1.Time
+	switch err := r.Get(ctx, req.NamespacedName, obj); {
+	case kerrors.IsNotFound(err):
+		logger = logger.WithValues("reconciliation_action", "delete")
+		deleted = &metav1.Time{Time: time.Now()}
+
+	case err != nil:
+		logger.Error(fmt.Errorf("could not get object from api server: %w", err), "failed reconciliation")
+		return ctrl.Result{}, fmt.Errorf("could not get referenced object %v: %w", req.NamespacedName, err)
+
+	default:
+		logger = logger.WithValues("uid", obj.GetUID(), "reconciliation_action", "upsert")
+	}
+
+	var allErrs error
+	for _, orgID := range orgs {
+		requestID := uuid.New().String()
+		reqLogger := logger.WithValues("organization_id", orgID, "request_id", requestID)
+		ctx = log.IntoContext(ctx, reqLogger)
+
+		if err := r.Store.Upsert(ctx, requestID, obj, r.gvk.PreferredVersion, orgID, deleted); err != nil {
+			var httpErr *backend.HTTPError
+			if errors.As(err, &httpErr) {
+				// when zap finds an `error` type in the values, it will call `Error` and print that
+				// message in the logs. We want to get the underlying values though, to have indexed
+				// fields.
+				reqLogger = reqLogger.WithValues("http_response_error", httpErr.Values())
+			}
+
+			reqLogger.Error(fmt.Errorf("could not upsert to store: %w", err), "failed reconciliation")
+			if allErrs == nil {
+				allErrs = err
+			} else {
+				allErrs = fmt.Errorf("%w, %w", err, allErrs)
+			}
+		} else {
+			reqLogger.Info("successful upsert")
+		}
+
+	}
+
+	if allErrs != nil {
+		return ctrl.Result{}, allErrs
+	}
+
+	logger.Info("successful reconciliation")
+	// don't requeue after deletion.
+	if deleted != nil {
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{RequeueAfter: r.requeueAfter}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	o := &unstructured.Unstructured{}
+	o.SetGroupVersionKind(r.gvk.GroupVersionKind)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(o).
+		Complete(r)
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -44,7 +44,6 @@ const (
 )
 
 func TestController(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip("not running controller tests that spawn API server")
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package main
+package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -78,7 +77,7 @@ func TestController(t *testing.T) {
 		MetricsAddress: "localhost:9091",
 	}
 
-	if err := waitForAPI(ctx, c); err != nil {
+	if err := controllertest.WaitForAPI(ctx, c); err != nil {
 		t.Fatalf("error waiting for API: %v", err)
 	}
 
@@ -126,7 +125,7 @@ func TestController(t *testing.T) {
 	go func() {
 		defer backendCancel()
 
-		mgr, err := setupController(cfg, fb)
+		mgr, err := New(cfg, fb)
 		if err != nil {
 			t.Errorf("could not setup controller: %v", err)
 		}
@@ -477,16 +476,4 @@ func (c testClient) Create(ctx context.Context, obj client.Object, opts ...clien
 	defer obj.GetObjectKind().SetGroupVersionKind(gvk)
 
 	return c.Client.Create(ctx, obj, opts...)
-}
-
-func waitForAPI(ctx context.Context, c client.Client) error {
-	for {
-		if err := c.Get(ctx, types.NamespacedName{Name: "default"}, &corev1.Namespace{}); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("timeout waiting for API to be ready")
-			}
-			continue
-		}
-		return nil
-	}
 }

--- a/main.go
+++ b/main.go
@@ -16,34 +16,21 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/snyk/kubernetes-scanner/build"
 	"github.com/snyk/kubernetes-scanner/internal/backend"
 	"github.com/snyk/kubernetes-scanner/internal/config"
+	"github.com/snyk/kubernetes-scanner/internal/controller"
 	"github.com/snyk/kubernetes-scanner/licenses"
 
-	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
-
-var setupLog = ctrl.Log.WithName("setup")
 
 func main() {
 	var (
@@ -59,255 +46,39 @@ func main() {
 
 	logOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&logOpts)))
 
-	if *printVersion {
+	switch {
+	case *printVersion:
 		fmt.Println(build.Version())
-		os.Exit(0)
-	}
-	if *showLicenses {
+
+	case *showLicenses:
 		os.Exit(licenses.Print())
-	}
-
-	cfg, err := config.Read(*configFile)
-	if err != nil {
-		setupLog.Error(err, "unable to read config file")
-		os.Exit(1)
-	}
-
-	mgr, err := setupController(cfg, backend.New(cfg.ClusterName, cfg.Egress, ctrlmetrics.Registry))
-	if err != nil {
-		setupLog.Error(err, "unable to setup controller")
-		os.Exit(1)
-	}
-
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-}
-
-func setupController(cfg *config.Config, s store) (manager.Manager, error) {
-	mgr, err := ctrl.NewManager(cfg.RestConfig, ctrl.Options{
-		Scheme:                 cfg.Scheme,
-		MetricsBindAddress:     cfg.MetricsAddress,
-		HealthProbeBindAddress: cfg.ProbeAddress,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to start manager: %w", err)
-	}
-
-	discovery, err := cfg.Discovery()
-	if err != nil {
-		return nil, fmt.Errorf("unable to create discovery client: %w", err)
-	}
-
-	for _, scanType := range cfg.Scanning.Types {
-		gvks, err := scanType.GetGVKs(discovery, setupLog)
-		if err != nil {
-			return nil, fmt.Errorf("could not get GVK: %w", err)
-		}
-
-		for _, gvk := range gvks {
-			if err := (&reconciler{
-				Reader:       mgr.GetClient(),
-				requeueAfter: cfg.Scanning.RequeueAfter.Duration,
-				store:        s,
-				gvk:          gvk,
-				routes:       newResourceRoutes(cfg.Routes),
-				namespaces:   scanType.Namespaces,
-			}).SetupWithManager(mgr); err != nil {
-				return nil, fmt.Errorf("unable to create controller for GVK %v: %w", gvk, err)
-			}
-		}
-	}
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("unable to setup health check: %w", err)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("unable to setup readiness check: %w", err)
-	}
-
-	return mgr, nil
-}
-
-type reconciler struct {
-	client.Reader
-	requeueAfter time.Duration
-	gvk          config.GroupVersionKind
-	store
-	namespaces []string
-	routes     resourceRoutes
-}
-
-type resourceRoutes struct {
-	clusterResources []string
-	namespaceRoutes  map[string][]string
-}
-
-func newResourceRoutes(routes []config.Route) resourceRoutes {
-	cfg := resourceRoutes{
-		clusterResources: []string{},
-		namespaceRoutes:  map[string][]string{},
-	}
-
-	// Creating clusterResources with unique organizationIDs
-	// This de-duplicates possible misconfiguration with multiple ClusterScopedResources:true defined for same org
-	clusterRouteSet := map[string]bool{}
-	for _, route := range routes {
-		if route.ClusterScopedResources {
-			clusterRouteSet[route.OrganizationID] = true
-		}
-	}
-	for orgID := range clusterRouteSet {
-		cfg.clusterResources = append(cfg.clusterResources, orgID)
-	}
-
-	// Set with unique organizationIDs -> orgId -> namespace -> bool
-	namespaceRouteSet := map[string]map[string]bool{}
-	for _, route := range routes {
-		if namespaceRouteSet[route.OrganizationID] == nil {
-			namespaceRouteSet[route.OrganizationID] = map[string]bool{}
-		}
-		for _, ns := range route.Namespaces {
-			namespaceRouteSet[route.OrganizationID][ns] = true
-		}
-	}
-	// If there is a wildcard namespace route for an organization, do not store other namespace routes.
-	// This helps to de-duplicate if an organization was configured with ["*", "ns-1", ....]
-	for orgID, namespaceRoutes := range namespaceRouteSet {
-		if namespaceRoutes["*"] {
-			cfg.namespaceRoutes["*"] = append(cfg.namespaceRoutes["*"], orgID)
-		} else {
-			for ns := range namespaceRoutes {
-				cfg.namespaceRoutes[ns] = append(cfg.namespaceRoutes[ns], orgID)
-			}
-		}
-	}
-	return cfg
-}
-
-// targetOrganizations returns target organizations for given request based on config.Routes
-// Resources can be configured to be routed for zero or more organizations
-func (r resourceRoutes) targetOrganizations(req ctrl.Request) []string {
-	if req.Namespace == "" {
-		return r.clusterResources
-	}
-	// For namespaced resource, return all organizations with * and this specific namespace routes
-	return append(r.namespaceRoutes[req.Namespace], r.namespaceRoutes["*"]...)
-}
-
-type store interface {
-	// Upsert an object into the store. If the deletedAt time is non-zero, a deletion-event should
-	// be recorded. Otherwise, the store should simply ensure that the object saved in the store
-	// matches the one we're providing.
-	Upsert(ctx context.Context, requestID string, obj client.Object, preferredVersion, orgID string, deletedAt *metav1.Time) error
-}
-
-// newObject creates a new object for this reconciler with the reconciler's GVK and the requests
-// name & namespace. This is all we know about an object without getting it from the Kube API.
-func (r *reconciler) newObject(req ctrl.Request) client.Object {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(r.gvk.GroupVersionKind)
-	obj.SetName(req.Name)
-	obj.SetNamespace(req.Namespace)
-
-	return obj
-}
-
-// isIgnored returns true if the given request should be ignored / skipped due to the namespace of
-// the request and the setup of this reconciler.
-func (r *reconciler) isIgnored(req ctrl.Request) bool {
-	// as long as r.namespaces is set, we want to check it. It might be 0-length, which will skip
-	// all namespaced resources. This is expected behavior.
-	return req.Namespace != "" && r.namespaces != nil &&
-		!slices.Contains(r.namespaces, req.Namespace)
-}
-
-func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx,
-		"resource", map[string]string{
-			"group":     r.gvk.Group,
-			"version":   r.gvk.Version,
-			"kind":      r.gvk.Kind,
-			"name":      req.Name,
-			"namespace": req.Namespace,
-		},
-	)
-	logger.Info("reconciling resource")
-
-	if r.isIgnored(req) {
-		logger.Info("skipping resources as namespace is ignored")
-		// Ignored resource means we don't need to requeue it either.
-		return ctrl.Result{}, nil
-	}
-
-	orgs := r.routes.targetOrganizations(req)
-	if len(orgs) == 0 {
-		logger.Info("skipping resources as namespace has no routes")
-		return ctrl.Result{}, nil
-	}
-
-	obj := r.newObject(req)
-	var deleted *metav1.Time
-	switch err := r.Get(ctx, req.NamespacedName, obj); {
-	case kerrors.IsNotFound(err):
-		logger = logger.WithValues("reconciliation_action", "delete")
-		deleted = &metav1.Time{Time: time.Now()}
-
-	case err != nil:
-		logger.Error(fmt.Errorf("could not get object from api server: %w", err), "failed reconciliation")
-		return ctrl.Result{}, fmt.Errorf("could not get referenced object %v: %w", req.NamespacedName, err)
 
 	default:
-		logger = logger.WithValues("uid", obj.GetUID(), "reconciliation_action", "upsert")
+		os.Exit(runController(*configFile, &logOpts))
 	}
-
-	var allErrs error
-	for _, orgID := range orgs {
-		requestID := uuid.New().String()
-		logger = logger.WithValues("organization_id", orgID, "request_id", requestID)
-		ctx = log.IntoContext(ctx, logger)
-		if err := r.store.Upsert(ctx, requestID, obj, r.gvk.PreferredVersion, orgID, deleted); err != nil {
-			var httpErr *backend.HTTPError
-			if errors.As(err, &httpErr) {
-				// when zap finds an `error` type in the values, it will call `Error` and print that
-				// message in the logs. We want to get the underlying values though, to have indexed
-				// fields.
-				logger = logger.WithValues("http_response_error", httpErr.Values())
-			}
-
-			logger.Error(fmt.Errorf("could not upsert to store: %w", err), "failed reconciliation")
-			if allErrs == nil {
-				allErrs = err
-			} else {
-				allErrs = fmt.Errorf("%w, %w", err, allErrs)
-			}
-		} else {
-			logger.Info("successful reconciliation")
-		}
-	}
-
-	if allErrs != nil {
-		return ctrl.Result{}, allErrs
-	}
-
-	// don't requeue after deletion.
-	if deleted != nil {
-		return ctrl.Result{}, nil
-	}
-
-	return ctrl.Result{RequeueAfter: r.requeueAfter}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	o := &unstructured.Unstructured{}
-	o.SetGroupVersionKind(r.gvk.GroupVersionKind)
+func runController(configFile string, logOpts *zap.Options) (code int) {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	return ctrl.NewControllerManagedBy(mgr).
-		For(o).
-		Complete(r)
+	cfg, err := config.Read(configFile)
+	if err != nil {
+		ctrl.Log.Error(err, "error reading config file")
+		return 1
+	}
+
+	mgr, err := controller.New(cfg, backend.New(cfg.ClusterName, cfg.Egress, ctrlmetrics.Registry))
+	if err != nil {
+		ctrl.Log.Error(err, "error setting up controller")
+		return 1
+	}
+
+	ctrl.Log.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		ctrl.Log.Error(err, "error running manager")
+		return 1
+	}
+
+	return 0
 }


### PR DESCRIPTION
**refactor: move code**

This commit moves most of the controller-logic from the `main` package
into it's own internal package so that we could later import it for the
smoke-tests.

**feat: implement list endpoint in backend**

To be used in tests.

**refactor: move out kubernetes manifest parser**

We'll need it in the test as well.

-----

I've talked to @srlk about this - these are the changes I've made when I started with the Smoke tests.

I didn't get far and am not 100% sure if the refactors are really needed, but we figured we could still open that PR and get these changes in separately. 

I'm also happy to drop some commits here, for example I'm pretty sure that we'll need the `List` functionality, but we could drop the refactors if that is some "premature ~optimization~ refactoring" :) 
