### PR TITLE
[TIKI-104] feat: attribute removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,40 @@ There are some mandatory fields, each marked with "MANDATORY" in a comment.
 
 See [monitoring.md](docs/monitoring.md).
 
+### Removing resource attributes
+
+While Kubernetes `v1.Secrets` are designed to separate secret fields into their
+own types, referenced in other types' fields such as container environment
+variable `secretKeyRefs`, some users may wish to prevent certain fields on
+certain types from being sent to Snyk, while still scanning other fields on that
+type.
+
+The scanner supports this sort of attribute removal, as an optional array of
+paths alongside group-version-kind scan config:
+
+```yaml
+- apiGroups: ["apps"]
+    versions: ["*"]
+    resources:
+      - replicasets
+      - daemonsets
+      - deployments
+      - statefulsets
+    attributeRemovals:
+      - "spec.template.spec.containers.env"
+      - "metadata.managedFields"
+```
+
+These paths are dot-separated address for nested values, in the same format as
+arguments to `kubectl explain`. For example, the expression
+"spec.containers.env" will cause Kubernetes Pod container environment variables
+to be removed. "containers" is an array, and each element of this array is
+redacted in this way.
+
+See
+[values.yaml](https://github.com/snyk/kubernetes-scanner/tree/main/helm/kubernetes-scanner/values.yaml)
+for examples in Helm values.
+
 ### HTTP proxy compatibility
 
 Some users may want the scanner to send its HTTP requests via a proxy, for

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -93,6 +93,18 @@ config:
         # e.g. ClusterRoles.
         # Declare an empty list to _only_ scan non-namespaced resources.
         # namespaces: ["default"]
+        #
+        # Optionally configure fields to be removed.
+        # These paths are dot-separated address for nested values, in the same
+        # format as arguments to `kubectl explain`.
+        # For example, the expression "spec.containers.env" will cause
+        # Kubernetes Pod container environment variables to be removed.
+        # "containers" is an array, and each element of this array is
+        # redacted in this way.
+        #
+        # attributeRemovals:
+        #   - "spec.containers.env"
+        #   - "metadata.managedFields"
       - apiGroups: ["rbac.authorization.k8s.io"]
         versions: ["*"]
         resources:
@@ -112,6 +124,10 @@ config:
           - daemonsets
           - deployments
           - statefulsets
+        # More example attributeRemovals. See above for explanation.
+        # attributeRemovals:
+        #   - "spec.template.spec.containers.env"
+        #   - "metadata.managedFields"
       - apiGroups: ["networking.k8s.io"]
         versions: ["*"]
         resources:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,6 +193,13 @@ type ScanType struct {
 	// namespaces. Omit to scan resources in all namespaces. Does not affect the scanning of
 	// cluster-scoped resources.
 	Namespaces []string `json:"namespaces,omitempty"`
+
+	// These are dot-separated address for nested values, in the same format as
+	// arguments to `kubectl explain`.
+	// For example, the expr "spec.containers.env" will cause Kubernetes Pod
+	// container environment variables to be removed. "containers" is an array,
+	// and each element of this array is removed.
+	PathsToRemove []string `json:"attributeRemovals"`
 }
 
 // GetGVKs returns all the GVKs that are defined in the ScanType and are available on the server.

--- a/internal/kubeobjects/attrremoval.go
+++ b/internal/kubeobjects/attrremoval.go
@@ -1,0 +1,54 @@
+package kubeobjects
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// `expr` is a dot-separated address for nested values, in the same format as
+// arguments to `kubectl explain`.
+// For example, the expr "spec.containers.env" will cause Kubernetes Pod
+// container environment variables to be removed. "containers" is an array, and
+// each element of this array is redacted.
+func RemoveAttributes(obj *unstructured.Unstructured, expr string) {
+	exprParts := strings.Split(expr, ".")
+	// we always pass in a map[string]interface{}, so we should always get the same type out.
+	obj.Object = removeAttributes(obj.Object, exprParts).(map[string]interface{})
+}
+
+// removeAttributes removes the dot-separated address from the given JSON object. "JSON object"
+// means it needs to be a JSON compatible type, which is either a basic type (string, float, int or
+// bool), []interface{} or map[string]interface{}.
+// These are the same constraints that an `unstructured.Unstructured.Object` has
+// (see https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured).
+func removeAttributes(jsonObj interface{}, exprParts []string) interface{} {
+	currentPart := exprParts[0]
+	remainingParts := exprParts[1:]
+
+	switch val := jsonObj.(type) {
+	case map[string]interface{}:
+		if len(remainingParts) == 0 {
+			delete(val, currentPart)
+			return val
+		}
+
+		val[currentPart] = removeAttributes(val[currentPart], remainingParts)
+		return val
+
+	case []interface{}:
+		redactedVals := make([]interface{}, len(val))
+		for i, v := range val {
+			redactedVals[i] = removeAttributes(v, exprParts)
+		}
+		return redactedVals
+
+	default:
+		// Since the root node of a Kubernetes resource is always a map, and
+		// removal expressions contain key names, we should be guaranteed to
+		// remove desired scalar values when the function is visiting a map. We only
+		// land in this branch when we are redacting a mixed-type array that
+		// contains some scalars. We can return the scalars directly here.
+		return val
+	}
+}

--- a/internal/kubeobjects/attrremoval_test.go
+++ b/internal/kubeobjects/attrremoval_test.go
@@ -1,0 +1,197 @@
+package kubeobjects_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/kubernetes-scanner/internal/kubeobjects"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRemoveAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		input, expected map[string]interface{}
+		expr            string
+	}{
+		{
+			name: "empty removal expression is a no-op",
+			input: map[string]interface{}{
+				"foo": "bar",
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "removes scalar fields",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": "barry",
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+			expr: "baz",
+		},
+		{
+			name: "removes object fields",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"one": 1,
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+			expr: "baz",
+		},
+		{
+			name: "removes array fields",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": []int{1, 2},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+			expr: "baz",
+		},
+		{
+			name: "removes fields nested in objects",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"barry": map[string]interface{}{
+						"field1": float64(1),
+						"field2": float64(2),
+						"field3": float64(3),
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"barry": map[string]interface{}{
+						"field1": float64(1),
+						"field3": float64(3),
+					},
+				},
+			},
+			expr: "baz.barry.field2",
+		},
+		{
+			name: "removes fields nested in arrays",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"arr": []interface{}{
+						map[string]interface{}{
+							"field1": float64(1),
+							"field2": float64(2),
+							"field3": float64(3),
+						},
+						map[string]interface{}{
+							"field1": float64(1),
+							"field2": float64(2),
+							"field3": float64(3),
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"arr": []interface{}{
+						map[string]interface{}{
+							"field1": float64(1),
+							"field3": float64(3),
+						},
+						map[string]interface{}{
+							"field1": float64(1),
+							"field3": float64(3),
+						},
+					},
+				},
+			},
+			expr: "baz.arr.field2",
+		},
+		{
+			name: "removes fields nested in arrays when there are scalar values present in a mixed-type array",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"arr": []interface{}{
+						map[string]interface{}{
+							"field1": float64(1),
+							"field2": float64(2),
+							"field3": float64(3),
+						},
+						"a-string",
+						map[string]interface{}{
+							"field1": float64(1),
+							"field2": float64(2),
+							"field3": float64(3),
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"arr": []interface{}{
+						map[string]interface{}{
+							"field1": float64(1),
+							"field3": float64(3),
+						},
+						"a-string",
+						map[string]interface{}{
+							"field1": float64(1),
+							"field3": float64(3),
+						},
+					},
+				},
+			},
+			expr: "baz.arr.field2",
+		},
+		{
+			name: "non-existent field removal is a no-op",
+			input: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			},
+			expr: "foo.barry",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: tc.input}
+			kubeobjects.RemoveAttributes(obj, tc.expr)
+			require.Equal(t, tc.expected, obj.Object)
+		})
+	}
+}
+
+func TestRemoveAttributesFromRealManifest(t *testing.T) {
+	manifestBytes, err := os.ReadFile(filepath.Join("testdata", "daemonset.json"))
+	require.NoError(t, err)
+	var original map[string]interface{}
+	require.NoError(t, json.Unmarshal(manifestBytes, &original))
+
+	redactedManifestBytes, err := os.ReadFile(filepath.Join("testdata", "daemonset-redacted.json"))
+	require.NoError(t, err)
+	var expected interface{}
+	require.NoError(t, json.Unmarshal(redactedManifestBytes, &expected))
+
+	kubeobjects.RemoveAttributes(&unstructured.Unstructured{Object: original}, "spec.template.spec.containers.env")
+	require.Equal(t, expected, original)
+}

--- a/internal/kubeobjects/testdata/daemonset-redacted.json
+++ b/internal/kubeobjects/testdata/daemonset-redacted.json
@@ -1,0 +1,125 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "annotations": {
+      "deprecated.daemonset.template.generation": "1"
+    },
+    "creationTimestamp": "2023-03-28T15:28:41Z",
+    "generation": 1,
+    "labels": {
+      "k8s-app": "kube-proxy"
+    },
+    "name": "kube-proxy",
+    "namespace": "kube-system",
+    "resourceVersion": "310271",
+    "uid": "4ffd0a5c-d8be-448c-990a-ca988b9c982d"
+  },
+  "spec": {
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "k8s-app": "kube-proxy"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "k8s-app": "kube-proxy"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/usr/local/bin/kube-proxy",
+              "--config=/var/lib/kube-proxy/config.conf",
+              "--hostname-override=$(NODE_NAME)"
+            ],
+            "image": "registry.k8s.io/kube-proxy:v1.25.4",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "kube-proxy",
+            "resources": {},
+            "securityContext": {
+              "privileged": true
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/lib/kube-proxy",
+                "name": "kube-proxy"
+              },
+              {
+                "mountPath": "/run/xtables.lock",
+                "name": "xtables-lock"
+              },
+              {
+                "mountPath": "/lib/modules",
+                "name": "lib-modules",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "hostNetwork": true,
+        "nodeSelector": {
+          "kubernetes.io/os": "linux"
+        },
+        "priorityClassName": "system-node-critical",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "kube-proxy",
+        "serviceAccountName": "kube-proxy",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+          {
+            "operator": "Exists"
+          }
+        ],
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "name": "kube-proxy"
+            },
+            "name": "kube-proxy"
+          },
+          {
+            "hostPath": {
+              "path": "/run/xtables.lock",
+              "type": "FileOrCreate"
+            },
+            "name": "xtables-lock"
+          },
+          {
+            "hostPath": {
+              "path": "/lib/modules",
+              "type": ""
+            },
+            "name": "lib-modules"
+          }
+        ]
+      }
+    },
+    "updateStrategy": {
+      "rollingUpdate": {
+        "maxSurge": 0,
+        "maxUnavailable": 1
+      },
+      "type": "RollingUpdate"
+    }
+  },
+  "status": {
+    "currentNumberScheduled": 1,
+    "desiredNumberScheduled": 1,
+    "numberAvailable": 1,
+    "numberMisscheduled": 0,
+    "numberReady": 1,
+    "observedGeneration": 1,
+    "updatedNumberScheduled": 1
+  }
+}

--- a/internal/kubeobjects/testdata/daemonset.json
+++ b/internal/kubeobjects/testdata/daemonset.json
@@ -1,0 +1,136 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "annotations": {
+      "deprecated.daemonset.template.generation": "1"
+    },
+    "creationTimestamp": "2023-03-28T15:28:41Z",
+    "generation": 1,
+    "labels": {
+      "k8s-app": "kube-proxy"
+    },
+    "name": "kube-proxy",
+    "namespace": "kube-system",
+    "resourceVersion": "310271",
+    "uid": "4ffd0a5c-d8be-448c-990a-ca988b9c982d"
+  },
+  "spec": {
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "k8s-app": "kube-proxy"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "k8s-app": "kube-proxy"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/usr/local/bin/kube-proxy",
+              "--config=/var/lib/kube-proxy/config.conf",
+              "--hostname-override=$(NODE_NAME)"
+            ],
+            "env": [
+              {
+                "name": "NODE_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "spec.nodeName"
+                  }
+                }
+              }
+            ],
+            "image": "registry.k8s.io/kube-proxy:v1.25.4",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "kube-proxy",
+            "resources": {},
+            "securityContext": {
+              "privileged": true
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/lib/kube-proxy",
+                "name": "kube-proxy"
+              },
+              {
+                "mountPath": "/run/xtables.lock",
+                "name": "xtables-lock"
+              },
+              {
+                "mountPath": "/lib/modules",
+                "name": "lib-modules",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "hostNetwork": true,
+        "nodeSelector": {
+          "kubernetes.io/os": "linux"
+        },
+        "priorityClassName": "system-node-critical",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "kube-proxy",
+        "serviceAccountName": "kube-proxy",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+          {
+            "operator": "Exists"
+          }
+        ],
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "name": "kube-proxy"
+            },
+            "name": "kube-proxy"
+          },
+          {
+            "hostPath": {
+              "path": "/run/xtables.lock",
+              "type": "FileOrCreate"
+            },
+            "name": "xtables-lock"
+          },
+          {
+            "hostPath": {
+              "path": "/lib/modules",
+              "type": ""
+            },
+            "name": "lib-modules"
+          }
+        ]
+      }
+    },
+    "updateStrategy": {
+      "rollingUpdate": {
+        "maxSurge": 0,
+        "maxUnavailable": 1
+      },
+      "type": "RollingUpdate"
+    }
+  },
+  "status": {
+    "currentNumberScheduled": 1,
+    "desiredNumberScheduled": 1,
+    "numberAvailable": 1,
+    "numberMisscheduled": 0,
+    "numberReady": 1,
+    "observedGeneration": 1,
+    "updatedNumberScheduled": 1
+  }
+}


### PR DESCRIPTION
Users can optionally configure a list of paths alongside scan type config, representing fields to remove from manifests before sending them to Snyk.