### PR TITLE
[CTX-613] chore: move ownership from cloud context to engines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/taskforce-insights-k8s-integration
+* @snyk/cloud-engines


### PR DESCRIPTION
As part of the Cloud Group consolidation, this repository's Cloud Context
ownership is moving to the engines team.
