### PR TITLE
fix: oldest failure age metric when there are no failures

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strconv"
 	"sync"
@@ -327,9 +326,7 @@ func newMetrics(registry prometheus.Registerer) *metrics {
 	}
 
 	registry.MustRegister(m)
-
-	// we need to set an initial value so that it is not 0.
-	m.oldestFailureTimestamp.Set(math.Inf(0))
+	m.oldestFailureTimestamp.Set(0)
 
 	return m
 }
@@ -404,7 +401,7 @@ func (m *metrics) recordSuccess(ctx context.Context, obj client.Object) {
 	}
 
 	if m.oldest == nil {
-		m.oldestFailureTimestamp.Set(math.Inf(0))
+		m.oldestFailureTimestamp.Set(0)
 		log.FromContext(ctx).Info("removed oldest failure, no new ones")
 	} else {
 		m.oldestFailureTimestamp.Set(float64(*m.oldest))
@@ -419,7 +416,7 @@ type upsertFailure struct {
 }
 
 func (m *metrics) Collect(ch chan<- prometheus.Metric) {
-	age := math.Inf(0)
+	age := float64(0)
 	if m.oldest != nil {
 		age = float64(now().Unix() - *m.oldest)
 	}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -390,7 +389,7 @@ func TestMetricsOldest(t *testing.T) {
 		requireGauge(t, registry, metricName, float64(*m.failures[newResourceID(res)].added))
 
 		m.recordSuccess(ctx, res)
-		requireGauge(t, registry, metricName, math.Inf(0))
+		requireGauge(t, registry, metricName, 0)
 	})
 
 	t.Run("cleanup with replacement", func(t *testing.T) {
@@ -424,7 +423,7 @@ func TestMetricsOldest(t *testing.T) {
 		requireGauge(t, registry, ageMetricName, 50)
 
 		m.recordSuccess(ctx, res)
-		requireGauge(t, registry, ageMetricName, math.Inf(0))
+		requireGauge(t, registry, ageMetricName, 0)
 	})
 }
 


### PR DESCRIPTION
Prior to this commit, we set this metric to +Inf, because semantically, the last error never happened. In practice, this is awkward. Following the recommendations in monitoring.md, a value of +Inf that actually represents a perfectly healthy state, would result in an alert that always fires.

Using zero instead is perhaps a little confusing, but better expresses what we care about from an alerting perspective: there is no persistent reconciliation failure.

---

Tangentially related to https://snyk.slack.com/archives/C04NZ6WLL4C/p1687450985727619 and https://github.com/snyk/datadog-infra/pull/423.

Discussed with @tommyknows and @srlk 