### PR TITLE
chore: different API base URL for smoke tess

### DIFF
--- a/test/smoke_test.go
+++ b/test/smoke_test.go
@@ -2,9 +2,9 @@ package test
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"reflect"
@@ -200,6 +200,14 @@ type helmValues struct {
 	Config config.Config `json:"config"`
 }
 
+func getSnykAPIBaseURL() string {
+	if api := os.Getenv("SNYK_API"); api != "" {
+		return api
+	}
+
+	return "https://api.dev.snyk.io"
+}
+
 func newHelmValues() (vals helmValues, filename string, err error) {
 	orgID := os.Getenv("TEST_ORGANIZATION_ID")
 	if orgID == "" {
@@ -229,7 +237,7 @@ func newHelmValues() (vals helmValues, filename string, err error) {
 				RequeueAfter: metav1.Duration{Duration: time.Hour},
 			},
 			Egress: &config.Egress{
-				SnykAPIBaseURL:          "https://api.dev.snyk.io",
+				SnykAPIBaseURL:          getSnykAPIBaseURL(),
 				SnykServiceAccountToken: snykSAToken,
 			},
 		},
@@ -256,9 +264,8 @@ func newHelmValues() (vals helmValues, filename string, err error) {
 
 // returns a new random cluster name with a "smoke_test_" prefix.
 func newClusterName() string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, 16)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	return fmt.Sprintf("smoke_test_%x", b)
 }
 


### PR DESCRIPTION
This commit introduces the usage of the "SNYK_API" environment variable to configure the backend / API URL where the smoke tests will run again.

This is useful to test different environments.

See [CLOUD-1682](https://snyksec.atlassian.net/browse/CLOUD-1682).

Note: So far, i think it was possible to run the smoke tests locally as well. I'm wondering if people might have set the `SNYK_API` variable in their environments, and this change would introduce a change in behaviour for them. 
However, I don't think that should be an issue, as usually when setting `SNYK_API`, you set it to `api.dev.snyk.io`, which is / was the fallback value anyways.

[CLOUD-1682]: https://snyksec.atlassian.net/browse/CLOUD-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ