### PR TITLE
chore: change context for smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ workflows:
             branches:
               ignore: [main, gh-pages]
           context:
-            - tiki-smoke-tests
+            - tiki-smoke-tests-dev16
   "Release":
     jobs:
       - "Go test and lint":


### PR DESCRIPTION
I've renamed / recreated the context that is being used for smoke tests. We could also consider running the scanner smoke tests against multiple environments, but i think this should be good enough.