### PR TITLE
chore: update node for semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
   semantic-release:
     resource_class: small
     docker:
-      - image: cimg/node:18.15
+      - image: cimg/node:18.18
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Needs at least Node 18.17.