### PR TITLE
fix: sanity check for credential only [IA-360]

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -65,8 +65,8 @@ func New(clusterName string, cfg *config.Egress, reg prometheus.Registerer) *Bac
 
 const contentTypeJSON = "application/vnd.api+json"
 
-func (b *Backend) SanityCheck(ctx context.Context, orgID string) error {
-	endpoint := fmt.Sprintf("%s/rest/orgs/%s?version=2024-04-11", b.apiEndpoint, orgID)
+func (b *Backend) SanityCheck(ctx context.Context) error {
+	endpoint := fmt.Sprintf("%s/rest/self?version=2024-04-22", b.apiEndpoint)
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
 	if err != nil {

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -128,14 +128,19 @@ func TestSanityBackend(t *testing.T) {
 	ts := httptest.NewServer(&tu)
 	defer ts.Close()
 
-	b := New("my-pet-cluster", &config.Egress{
+	b1 := New("my-pet-cluster", &config.Egress{
 		HTTPClientTimeout:       metav1.Duration{Duration: 1 * time.Second},
 		SnykAPIBaseURL:          ts.URL,
 		SnykServiceAccountToken: testToken,
 	}, prometheus.NewPedanticRegistry())
+	require.NoError(t, b1.SanityCheck(ctx))
 
-	require.NoError(t, b.SanityCheck(ctx, orgID))
-	require.Error(t, b.SanityCheck(ctx, "org-456"))
+	b2 := New("my-sneaky-cluster", &config.Egress{
+		HTTPClientTimeout:       metav1.Duration{Duration: 1 * time.Second},
+		SnykAPIBaseURL:          ts.URL,
+		SnykServiceAccountToken: "bad-token",
+	}, prometheus.NewPedanticRegistry())
+	require.Error(t, b2.SanityCheck(ctx))
 }
 
 type testUpstream struct {
@@ -154,7 +159,7 @@ func (tu *testUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(fmt.Sprintf("/hidden/orgs/%s/kubernetes_resources", tu.orgID), tu.handleKubernetesResources)
-	mux.HandleFunc(fmt.Sprintf("/rest/orgs/%s", tu.orgID), tu.handleOrg)
+	mux.HandleFunc(fmt.Sprintf("/rest/self"), tu.handleSelf)
 	mux.ServeHTTP(w, r)
 }
 
@@ -191,7 +196,7 @@ func (tu *testUpstream) handleKubernetesResources(w http.ResponseWriter, r *http
 	require.Equal(tu.t, expected, req.Data.Attributes.Resources)
 }
 
-func (tu *testUpstream) handleOrg(w http.ResponseWriter, r *http.Request) {
+func (tu *testUpstream) handleSelf(w http.ResponseWriter, r *http.Request) {
 }
 
 var pod = &corev1.Pod{

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -159,7 +159,7 @@ func (tu *testUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(fmt.Sprintf("/hidden/orgs/%s/kubernetes_resources", tu.orgID), tu.handleKubernetesResources)
-	mux.HandleFunc(fmt.Sprintf("/rest/self"), tu.handleSelf)
+	mux.HandleFunc("/rest/self", tu.handleSelf)
 	mux.ServeHTTP(w, r)
 }
 

--- a/main.go
+++ b/main.go
@@ -72,15 +72,13 @@ func runController(configFile string, logOpts *zap.Options) (code int) {
 	}
 
 	backend := backend.New(cfg.ClusterName, cfg.Egress, ctrlmetrics.Registry)
-	for _, org := range cfg.Organizations() {
-		err := retry.Retry(ctrl.Log, 3, 5*time.Second, func() error {
-			ctrl.Log.Info("sanity checking backend config", "org_id", org)
-			return backend.SanityCheck(context.Background(), org)
-		})
-		if err != nil {
-			ctrl.Log.Error(err, "sanity check failed")
-			return 1
-		}
+	err = retry.Retry(ctrl.Log, 3, 5*time.Second, func() error {
+		ctrl.Log.Info("sanity checking backend")
+		return backend.SanityCheck(context.Background())
+	})
+	if err != nil {
+		ctrl.Log.Error(err, "sanity check failed")
+		return 1
 	}
 
 	mgr, err := controller.New(cfg, backend)


### PR DESCRIPTION
In #77, I added a sanity check on startup.  However, because this requests `/orgs/{org_id}`, this sanity check fails in the case a customer is using a custom role that **only** has permissions to publish kubernetes resources.

This PR changes that sanity check to use `/self` instead, which should always be available.