### PR TITLE
feat: make log level configurable [IA-302] 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/oauth2 v0.12.0
 	helm.sh/helm/v3 v3.14.2
@@ -145,7 +146,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.23.0 // indirect

--- a/helm/kubernetes-scanner/templates/configmap.yaml
+++ b/helm/kubernetes-scanner/templates/configmap.yaml
@@ -29,6 +29,10 @@ data:
     probeAddress: ":{{ .Values.healthCheck.port }}"
     metricsAddress: ":{{ .Values.metrics.port }}"
     clusterName: {{ required "A clusterName is required" .Values.config.clusterName | quote }}
+    {{- if and .Values.config.logging .Values.config.logging.level }}
+    logging:
+      level: {{ .Values.config.logging.level }}
+    {{- end }}
     routes: 
       {{- toYaml .Values.config.routes | nindent 6 }}
     scanning:

--- a/helm/kubernetes-scanner/values.yaml
+++ b/helm/kubernetes-scanner/values.yaml
@@ -210,6 +210,11 @@ config:
   egress:
     httpClientTimeout: "5s"
     snykAPIBaseURL: "https://api.snyk.io"
+  # Optionally, you can set the logging level for the scanner.  Supported
+  # values include: `error`, `warn`, `info`, `debug`.  If not specified,
+  # defaults to `info`.
+  # logging:
+  #   level: info
 
 # MANDATORY: The name of a secret containing auth credentials, which must be
 # provisioned outside of this chart.

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -49,6 +49,9 @@ func TestHelmChartConfig(t *testing.T) {
 					"clusterScopedResources": true,
 				},
 			},
+			"logging": map[string]interface{}{
+				"level": "warn",
+			},
 		},
 		// while this doesn't test the correctness of the podMonitor, it at least ensures that it
 		// can be decoded and is templated correctly.
@@ -138,6 +141,9 @@ func checkConfigMap(t *testing.T, cm *corev1.ConfigMap) {
 			HTTPClientTimeout:       metav1.Duration{Duration: 5 * time.Second},
 			SnykAPIBaseURL:          "https://api.snyk.io",
 		},
+		Logging: Logging{
+			Level: "warn",
+		},
 	}
 	// these are just *some* GVKs, not all of them.
 	expectedGVKs := [][]GroupVersionKind{
@@ -185,6 +191,7 @@ func checkConfigMap(t *testing.T, cm *corev1.ConfigMap) {
 	require.Equal(t, expected.MetricsAddress, cfg.MetricsAddress)
 	require.Equal(t, expected.ProbeAddress, cfg.ProbeAddress)
 	require.Equal(t, expected.Egress, cfg.Egress)
+	require.Equal(t, expected.Logging, cfg.Logging)
 
 	d, err := cfg.Discovery()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -40,14 +40,8 @@ func main() {
 		printVersion = flag.Bool("version", false, "print the version of the kubernetes-scanner and exit")
 		configFile   = flag.String("config", "/etc/kubernetes-scanner/config.yaml", "defines the location of the config file")
 		showLicenses = flag.Bool("licenses", false, "show license information")
-		logOpts      = zap.Options{
-			// The various `zap-` flags in this struct definition can be passed to
-			// this program due to the call to BindFlags() below. None of this is
-			// exposed through helm, yet - a decision we might revisit.
-		}
 	)
 
-	logOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	switch {
@@ -58,18 +52,23 @@ func main() {
 		os.Exit(licenses.Print())
 
 	default:
-		os.Exit(runController(*configFile, &logOpts))
+		os.Exit(runController(*configFile))
 	}
 }
 
-func runController(configFile string, logOpts *zap.Options) (code int) {
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
-
+func runController(configFile string) (code int) {
+	zapOpts := []zap.Opts{}
 	cfg, err := config.Read(configFile)
 	if err != nil {
+		ctrl.SetLogger(zap.New(zapOpts...))
 		ctrl.Log.Error(err, "error reading config file")
 		return 1
 	}
+
+	if level, _ := cfg.Logging.ZapLevel(); level != nil {
+		zapOpts = append(zapOpts, zap.Level(level))
+	}
+	ctrl.SetLogger(zap.New(zapOpts...))
 
 	backend := backend.New(cfg.ClusterName, cfg.Egress, ctrlmetrics.Registry)
 	err = retry.Retry(ctrl.Log, 3, 5*time.Second, func() error {


### PR DESCRIPTION
This adds the following optional section to the helm configuration:

```yaml
config:
  logging:
    level: info  # or error, warn, debug
```